### PR TITLE
Update Maven Install plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,11 +102,6 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-install-plugin</artifactId>
-                <version>3.0.0-M1</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <executions>
                     <execution>


### PR DESCRIPTION
- [x] This pull request is created in the [jfrog/jenkins-jfrog-plugin](https://github.com/jfrog/jenkins-jfrog-plugin) repository.

Now after https://github.com/jfrog/jfrog-cli/pull/1726 is included in the latest JFrog CLI, we can use the newest Maven Install plugin.