### PR TITLE
Default setting of JFrog CLI relevant environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,6 @@ jf 'rt u target/ my-repo/'
 ```groovy
 pipeline {
     agent any
-    environment {
-        JFROG_CLI_BUILD_NAME = "$JOB_NAME"
-        JFROG_CLI_BUILD_NUMBER = "$BUILD_NUMBER"
-    }
     tools {
         jfrog 'jfrog-cli'
     }

--- a/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
@@ -112,18 +112,12 @@ public class JfStep<T> extends Builder implements SimpleBuildStep {
      */
     public Launcher.ProcStarter setupJFrogEnvironment(Run<?, ?> run, EnvVars env, Launcher launcher, TaskListener listener, FilePath workspace, String jfrogBinaryPath, boolean isWindows) throws IOException, InterruptedException {
         // Set relevant environment variables.
-        if (env.get(JFROG_CLI_BUILD_NAME) == null) {
-            // Setting Jenkins job name as the default build-info name.
-            env.put(JFROG_CLI_BUILD_NAME, env.get("JOB_NAME"));
-        }
-        if (env.get(JFROG_CLI_BUILD_NUMBER) == null) {
-            // Setting Jenkins build number as the default build-info number.
-            env.put(JFROG_CLI_BUILD_NUMBER, env.get("BUILD_NUMBER"));
-        }
-        if (env.get(JFROG_CLI_BUILD_URL) == null) {
-            // Setting the specific build URL.
-            env.put(JFROG_CLI_BUILD_URL, env.get("BUILD_URL"));
-        }
+        // Setting Jenkins job name as the default build-info name.
+        env.putIfAbsent(JFROG_CLI_BUILD_NAME, env.get("JOB_NAME"));
+        // Setting Jenkins build number as the default build-info number.
+        env.putIfAbsent(JFROG_CLI_BUILD_NUMBER, env.get("BUILD_NUMBER"));
+        // Setting the specific build URL.
+        env.putIfAbsent(JFROG_CLI_BUILD_URL, env.get("BUILD_URL"));
         // Set up a temporary Jfrog CLI home directory for a specific run.
         FilePath jfrogHomeTempDir = Utils.createAndGetJfrogCliHomeTempDir(workspace, String.valueOf(run.getNumber()));
         env.put(JFROG_CLI_HOME_DIR, jfrogHomeTempDir.getRemote());

--- a/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
@@ -98,16 +98,17 @@ public class JfStep<T> extends Builder implements SimpleBuildStep {
 
     /**
      * Configure all JFrog relevant environment variables and all servers (if they haven't been configured yet).
-     * @param run       running as a part of a specific build
-     * @param env       environment variables applicable to this step
-     * @param launcher  a way to start processes
-     * @param listener  a place to send output
-     * @param workspace a workspace to use for any file operations
+     *
+     * @param run             running as a part of a specific build
+     * @param env             environment variables applicable to this step
+     * @param launcher        a way to start processes
+     * @param listener        a place to send output
+     * @param workspace       a workspace to use for any file operations
      * @param jfrogBinaryPath path to jfrog cli binary on the filesystem
-     * @param isWindows is Windows the applicable OS
+     * @param isWindows       is Windows the applicable OS
+     * @return launcher applicable to this step.
      * @throws InterruptedException if the step is interrupted
      * @throws IOException          in case of any I/O error, or we failed to run the 'jf' command
-     * @return launcher applicable to this step.
      */
     public Launcher.ProcStarter setupJFrogEnvironment(Run<?, ?> run, EnvVars env, Launcher launcher, TaskListener listener, FilePath workspace, String jfrogBinaryPath, boolean isWindows) throws IOException, InterruptedException {
         // Set relevant environment variables.

--- a/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
@@ -38,6 +38,9 @@ import static io.jenkins.plugins.jfrog.JfrogInstallation.JFROG_BINARY_PATH;
 public class JfStep<T> extends Builder implements SimpleBuildStep {
     static final String STEP_NAME = "jf";
     static final String JFROG_CLI_HOME_DIR = "JFROG_CLI_HOME_DIR";
+    public static final String JFROG_CLI_BUILD_NAME = "JFROG_CLI_BUILD_NAME";
+    public static final String JFROG_CLI_BUILD_NUMBER = "JFROG_CLI_BUILD_NUMBER";
+    public static final String JFROG_CLI_BUILD_URL = "JFROG_CLI_BUILD_URL";
     protected String args;
 
     @DataBoundConstructor
@@ -81,14 +84,7 @@ public class JfStep<T> extends Builder implements SimpleBuildStep {
         }
 
         try {
-            // Set up a temporary Jfrog CLI home directory for a specific run.
-            FilePath jfrogHomeTempDir = Utils.createAndGetJfrogCliHomeTempDir(workspace, String.valueOf(run.getNumber()));
-            env.put(JFROG_CLI_HOME_DIR, jfrogHomeTempDir.getRemote());
-            Launcher.ProcStarter jfLauncher = launcher.launch().envs(env).pwd(workspace).stdout(listener);
-            // Configure all servers, skip if all server ids have already been configured.
-            if (shouldConfig(jfrogHomeTempDir)) {
-                configAllServers(jfLauncher, jfrogBinaryPath, isWindows, run.getParent());
-            }
+            Launcher.ProcStarter jfLauncher = setupJFrogEnvironment(run, env, launcher, listener, workspace, jfrogBinaryPath, isWindows);
             // Running the 'jf' command
             int exitValue = jfLauncher.cmds(builder).join();
             if (exitValue != 0) {
@@ -98,6 +94,45 @@ public class JfStep<T> extends Builder implements SimpleBuildStep {
             String errorMessage = "Couldn't execute 'jf' command. " + ExceptionUtils.getRootCauseMessage(e);
             throw new RuntimeException(errorMessage, e);
         }
+    }
+
+    /**
+     * Configure all JFrog relevant environment variables and all servers (if they haven't been configured yet).
+     * @param run       running as a part of a specific build
+     * @param env       environment variables applicable to this step
+     * @param launcher  a way to start processes
+     * @param listener  a place to send output
+     * @param workspace a workspace to use for any file operations
+     * @param jfrogBinaryPath path to jfrog cli binary on the filesystem
+     * @param isWindows is Windows the applicable OS
+     * @throws InterruptedException if the step is interrupted
+     * @throws IOException          in case of any I/O error, or we failed to run the 'jf' command
+     * @return launcher applicable to this step.
+     */
+    public Launcher.ProcStarter setupJFrogEnvironment(Run<?, ?> run, EnvVars env, Launcher launcher, TaskListener listener, FilePath workspace, String jfrogBinaryPath, boolean isWindows) throws IOException, InterruptedException {
+        // Set relevant environment variables.
+        if (env.get(JFROG_CLI_BUILD_NAME) == null) {
+            // Setting Jenkins job name as the default build-info name.
+            env.put(JFROG_CLI_BUILD_NAME, env.get("JOB_NAME"));
+        }
+        if (env.get(JFROG_CLI_BUILD_NUMBER) == null) {
+            // Setting Jenkins build number as the default build-info number.
+            env.put(JFROG_CLI_BUILD_NUMBER, env.get("BUILD_NUMBER"));
+        }
+        if (env.get(JFROG_CLI_BUILD_URL) == null) {
+            // Setting the specific build URL.
+            env.put(JFROG_CLI_BUILD_URL, env.get("BUILD_URL"));
+        }
+        // Set up a temporary Jfrog CLI home directory for a specific run.
+        FilePath jfrogHomeTempDir = Utils.createAndGetJfrogCliHomeTempDir(workspace, String.valueOf(run.getNumber()));
+        env.put(JFROG_CLI_HOME_DIR, jfrogHomeTempDir.getRemote());
+
+        Launcher.ProcStarter jfLauncher = launcher.launch().envs(env).pwd(workspace).stdout(listener);
+        // Configure all servers, skip if all server ids have already been configured.
+        if (shouldConfig(jfrogHomeTempDir)) {
+            configAllServers(jfLauncher, jfrogBinaryPath, isWindows, run.getParent());
+        }
+        return jfLauncher;
     }
 
     /**

--- a/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
@@ -99,7 +99,7 @@ public class JfStep<T> extends Builder implements SimpleBuildStep {
     /**
      * Configure all JFrog relevant environment variables and all servers (if they haven't been configured yet).
      *
-     * @param run             running as a part of a specific build
+     * @param run             running as part of a specific build
      * @param env             environment variables applicable to this step
      * @param launcher        a way to start processes
      * @param listener        a place to send output

--- a/src/main/java/io/jenkins/plugins/jfrog/JfrogInstallation.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfrogInstallation.java
@@ -65,8 +65,9 @@ public class JfrogInstallation extends ToolInstallation
         }
         String version = "";
         try {
-            version = "/" + Jenkins.getInstanceOrNull().getPlugin("jfrog").getWrapper().getVersion();
-        } catch (NullPointerException exception) {
+            version = Jenkins.getInstanceOrNull().getPlugin("jfrog").getWrapper().getVersion();
+            version = "/" + version.split(" ")[0];
+        } catch (NullPointerException | ArrayIndexOutOfBoundsException exception) {
         }
         env.putIfAbsent(JFROG_CLI_USER_AGENT, "jenkins-jfrog-plugin" + version);
     }

--- a/src/main/java/io/jenkins/plugins/jfrog/JfrogInstallation.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfrogInstallation.java
@@ -31,6 +31,7 @@ public class JfrogInstallation extends ToolInstallation
 
     public static final String JFROG_BINARY_PATH = "JFROG_BINARY_PATH";
     public static final String JFROG_CLI_DEPENDENCIES_DIR = "JFROG_CLI_DEPENDENCIES_DIR";
+    public static final String JFROG_CLI_USER_AGENT = "JFROG_CLI_USER_AGENT";
     public static final String JfrogDependenciesDirName = "dependencies";
 
     @DataBoundConstructor
@@ -60,6 +61,9 @@ public class JfrogInstallation extends ToolInstallation
             if (path != null) {
                 env.put(JFROG_CLI_DEPENDENCIES_DIR, path.resolve(JfrogDependenciesDirName).toString());
             }
+        }
+        if (env.get(JFROG_CLI_USER_AGENT) == null) {
+            env.put(JFROG_CLI_USER_AGENT, "jenkins-jfrog-plugin");
         }
     }
 

--- a/src/main/java/io/jenkins/plugins/jfrog/JfrogInstallation.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfrogInstallation.java
@@ -18,6 +18,7 @@ import org.kohsuke.stapler.StaplerRequest;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
@@ -55,7 +56,10 @@ public class JfrogInstallation extends ToolInstallation
         if (env.get(JFROG_CLI_DEPENDENCIES_DIR) == null) {
             // Jfrog CLI dependencies directory is a sibling of all the other tools directories.
             // By doing this, we avoid downloading dependencies separately for each job in its temporary Jfrog home directory.
-            env.put(JFROG_CLI_DEPENDENCIES_DIR, Paths.get(home).getParent().resolve(JfrogDependenciesDirName).toString());
+            Path path = Paths.get(home).getParent();
+            if (path != null) {
+                env.put(JFROG_CLI_DEPENDENCIES_DIR, path.resolve(JfrogDependenciesDirName).toString());
+            }
         }
     }
 

--- a/src/main/java/io/jenkins/plugins/jfrog/JfrogInstallation.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfrogInstallation.java
@@ -3,6 +3,8 @@ package io.jenkins.plugins.jfrog;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.EnvVars;
 import hudson.Extension;
+import hudson.Plugin;
+import hudson.PluginWrapper;
 import hudson.model.EnvironmentSpecific;
 import hudson.model.Node;
 import hudson.model.TaskListener;
@@ -63,13 +65,25 @@ public class JfrogInstallation extends ToolInstallation
                 env.put(JFROG_CLI_DEPENDENCIES_DIR, path.resolve(JfrogDependenciesDirName).toString());
             }
         }
-        String version = "";
-        try {
-            version = Jenkins.getInstanceOrNull().getPlugin("jfrog").getWrapper().getVersion();
-            version = "/" + version.split(" ")[0];
-        } catch (NullPointerException | ArrayIndexOutOfBoundsException exception) {
+        env.putIfAbsent(JFROG_CLI_USER_AGENT, "jenkins-jfrog-plugin" + getPluginVersion());
+    }
+
+    private String getPluginVersion() {
+        Jenkins jenkins =  Jenkins.getInstanceOrNull();
+        if (jenkins == null) {
+            return "";
         }
-        env.putIfAbsent(JFROG_CLI_USER_AGENT, "jenkins-jfrog-plugin" + version);
+        Plugin plugin = jenkins.getPlugin("jfrog");
+        if (plugin == null) {
+            return "";
+        }
+        PluginWrapper wrapper = plugin.getWrapper();
+        if (wrapper == null) {
+            return "";
+        }
+        String version = wrapper.getVersion();
+        // Return only the version prefix, without the agent information.
+        return "/" + version.split(" ")[0];
     }
 
     @Symbol("jfrog")

--- a/src/main/java/io/jenkins/plugins/jfrog/JfrogInstallation.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfrogInstallation.java
@@ -18,6 +18,7 @@ import org.kohsuke.stapler.StaplerRequest;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -28,6 +29,8 @@ public class JfrogInstallation extends ToolInstallation
         implements NodeSpecific<JfrogInstallation>, EnvironmentSpecific<JfrogInstallation> {
 
     public static final String JFROG_BINARY_PATH = "JFROG_BINARY_PATH";
+    public static final String JFROG_CLI_DEPENDENCIES_DIR = "JFROG_CLI_DEPENDENCIES_DIR";
+    public static final String JfrogDependenciesDirName = "dependencies";
 
     @DataBoundConstructor
     public JfrogInstallation(String name, String home, List<? extends ToolProperty<?>> properties) {
@@ -49,6 +52,11 @@ public class JfrogInstallation extends ToolInstallation
             return;
         }
         env.put(JFROG_BINARY_PATH, home);
+        if (env.get(JFROG_CLI_DEPENDENCIES_DIR) == null) {
+            // Jfrog CLI dependencies directory is a sibling of all the other tools directories.
+            // By doing this, we avoid downloading dependencies separately for each job in its temporary Jfrog home directory.
+            env.put(JFROG_CLI_DEPENDENCIES_DIR, Paths.get(home).getParent().resolve(JfrogDependenciesDirName).toString());
+        }
     }
 
     @Symbol("jfrog")

--- a/src/main/java/io/jenkins/plugins/jfrog/JfrogInstallation.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfrogInstallation.java
@@ -11,6 +11,7 @@ import hudson.tools.ToolDescriptor;
 import hudson.tools.ToolInstallation;
 import hudson.tools.ToolInstaller;
 import hudson.tools.ToolProperty;
+import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -62,9 +63,12 @@ public class JfrogInstallation extends ToolInstallation
                 env.put(JFROG_CLI_DEPENDENCIES_DIR, path.resolve(JfrogDependenciesDirName).toString());
             }
         }
-        if (env.get(JFROG_CLI_USER_AGENT) == null) {
-            env.put(JFROG_CLI_USER_AGENT, "jenkins-jfrog-plugin");
+        String version = "";
+        try {
+            version = "/" + Jenkins.getInstanceOrNull().getPlugin("jfrog").getWrapper().getVersion();
+        } catch (NullPointerException exception) {
         }
+        env.putIfAbsent(JFROG_CLI_USER_AGENT, "jenkins-jfrog-plugin" + version);
     }
 
     @Symbol("jfrog")

--- a/src/main/java/io/jenkins/plugins/jfrog/configuration/Credentials.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/configuration/Credentials.java
@@ -29,12 +29,6 @@ public class Credentials implements Serializable {
         this.accessToken = accessToken;
     }
 
-    public Credentials() {
-        this.username = EMPTY_SECRET;
-        this.password = EMPTY_SECRET;
-        this.accessToken = EMPTY_SECRET;
-    }
-
     public Secret getUsername() {
         return username;
     }


### PR DESCRIPTION
- [x] This pull request is created in the [jfrog/jenkins-jfrog-plugin](https://github.com/jfrog/jenkins-jfrog-plugin) repository.

Set 4 environment variables with a default value (in case they are empty):
1. JFROG_CLI_DEPENDENCIES_DIR: 
    By doing this, we avoid downloading dependencies separately for each job in its temporary Jfrog home directory.
2. JFROG_CLI_BUILD_NAME & JFROG_CLI_BUILD_NUMBER
3. JFROG_CLI_BUILD_URL