### PR TITLE
Details of the JFrog CLI tool are not being saved to the filesystem.

### DIFF
--- a/src/main/java/io/jenkins/plugins/jfrog/JfrogInstallation.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfrogInstallation.java
@@ -91,7 +91,7 @@ public class JfrogInstallation extends ToolInstallation
     public static final class Descriptor extends ToolDescriptor<JfrogInstallation> {
 
         public Descriptor() {
-            setInstallations();
+            super(JfrogInstallation.class);
             load();
         }
 
@@ -112,6 +112,17 @@ public class JfrogInstallation extends ToolInstallation
             // The default installation will be from 'releases.jfrog.io'
             installersList.add(new ReleasesInstaller(null));
             return installersList;
+        }
+
+        @Override
+        public boolean configure(StaplerRequest req, JSONObject o) throws FormException {
+            Jenkins jenkins = Jenkins.getInstanceOrNull();
+            if (jenkins != null && jenkins.hasPermission(Jenkins.ADMINISTER)) {
+                super.configure(req, o);
+                save();
+                return true;
+            }
+            throw new FormException("User doesn't have permissions to save", "Server ID");
         }
     }
 }


### PR DESCRIPTION
- [x] This pull request is created in the [jfrog/jenkins-jfrog-plugin](https://github.com/jfrog/jenkins-jfrog-plugin) repository.
The bug caused a problem when restarting Jenkins - The JFrog CLI tool's settings were deleted and had to be configured again manually. 