### PR TITLE
Add the Git plugin as a dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,10 @@
             <artifactId>plain-credentials</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>git</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.jenkins-ci.main</groupId>
             <artifactId>jenkins-test-harness</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
- [x] This pull request is created in the [jfrog/jenkins-jfrog-plugin](https://github.com/jfrog/jenkins-jfrog-plugin) repository.

Resolve the following issue:
1. Add clone stage:
```groovy
stage('Clone') {
    steps {
        git branch: 'master', url: "https://github.com/jfrog/project-examples.git"
    }
}
```
2. Receive the following error:
```groovy
org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
WorkflowScript: 9: Invalid parameter “branch”, did you mean “name”? @ line 9, column 21.
                   git branch: ‘master’, url: “https://github.com/jfrog/project-examples.git”
```

The examples in https://github.com/jfrog/jenkins-jfrog-plugin/pull/18 may not work without this.