### PR TITLE
Don't allow HTTP connections by default

### DIFF
--- a/src/main/java/io/jenkins/plugins/jfrog/configuration/JFrogPlatformBuilder.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/configuration/JFrogPlatformBuilder.java
@@ -30,8 +30,8 @@ import java.util.Set;
  * @author gail
  */
 public class JFrogPlatformBuilder extends GlobalConfiguration {
-    private static final String UNSAFE_HTTP_ERROR = "HTTP connections to the JFrog platform services are not allowed. " +
-            "To bypass this rule, check 'Allow HTTP Connections'.";
+    private static final String UNSAFE_HTTP_ERROR = "HTTP (non HTTPS) connections to the JFrog platform services are " +
+            "not allowed. To bypass this rule, check 'Allow HTTP Connections'.";
 
     /**
      * Descriptor for {@link JFrogPlatformBuilder}. Used as a singleton.
@@ -255,9 +255,12 @@ public class JFrogPlatformBuilder extends GlobalConfiguration {
      * @return true if the URL is using an unsafe HTTP protocol and the "Allow HTTP Connection" option is not set.
      */
     static boolean isUnsafe(boolean allowHttpConnections, String... urls) {
+        if (allowHttpConnections) {
+            return false;
+        }
         for (String url : urls) {
             //noinspection HttpUrlsUsage
-            if (!allowHttpConnections && StringUtils.startsWith(url, "http://")) {
+            if (StringUtils.startsWith(url, "http://")) {
                 return true;
             }
         }

--- a/src/main/java/io/jenkins/plugins/jfrog/configuration/JFrogPlatformBuilder.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/configuration/JFrogPlatformBuilder.java
@@ -30,6 +30,8 @@ import java.util.Set;
  * @author gail
  */
 public class JFrogPlatformBuilder extends GlobalConfiguration {
+    private static final String UNSAFE_HTTP_ERROR = "HTTP connections to the JFrog platform services are not allowed. " +
+            "To bypass this rule, check 'Allow HTTP Connections'.";
 
     /**
      * Descriptor for {@link JFrogPlatformBuilder}. Used as a singleton.
@@ -38,6 +40,7 @@ public class JFrogPlatformBuilder extends GlobalConfiguration {
     // this marker indicates Hudson that this is an implementation of an extension point.
     public static final class DescriptorImpl extends Descriptor<GlobalConfiguration> {
         private List<JFrogPlatformInstance> jfrogInstances;
+        private boolean allowHttpConnections;
 
         @SuppressWarnings("unused")
         public DescriptorImpl() {
@@ -84,18 +87,46 @@ public class JFrogPlatformBuilder extends GlobalConfiguration {
             return FormValidation.ok();
         }
 
-        /**
-         * Performs on-the-fly validation of the form field 'PlatformUrl'.
-         *
-         * @param value This parameter receives the value that the user has typed.
-         * @return Indicates the outcome of the validation. This is sent to the browser.
-         */
         @POST
         @SuppressWarnings("unused")
         public FormValidation doCheckPlatformUrl(@QueryParameter String value) {
             Jenkins.get().checkPermission(Jenkins.ADMINISTER);
             if (StringUtils.isBlank(value)) {
                 return FormValidation.error("Please set platform URL");
+            }
+            return checkUrlInForm(value);
+        }
+
+        @POST
+        @SuppressWarnings("unused")
+        public FormValidation doCheckArtifactoryUrl(@QueryParameter String value) {
+            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+            return checkUrlInForm(value);
+        }
+
+        @POST
+        @SuppressWarnings("unused")
+        public FormValidation doCheckDistributionUrl(@QueryParameter String value) {
+            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+            return checkUrlInForm(value);
+        }
+
+        @POST
+        @SuppressWarnings("unused")
+        public FormValidation doCheckXrayUrl(@QueryParameter String value) {
+            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+            return checkUrlInForm(value);
+        }
+
+        /**
+         * Performs on-the-fly validation of the form fields 'platformUrl', 'artifactoryUrl', 'distributionUrl', or 'xrayUrl'.
+         *
+         * @param value the URL value that the user has typed.
+         * @return the outcome of the validation. This is sent to the browser.
+         */
+        private FormValidation checkUrlInForm(String value) {
+            if (isUnsafe(isAllowHttpConnections(), value)) {
+                return FormValidation.error(UNSAFE_HTTP_ERROR);
             }
             return FormValidation.ok();
         }
@@ -104,6 +135,7 @@ public class JFrogPlatformBuilder extends GlobalConfiguration {
         public boolean configure(StaplerRequest req, JSONObject o) throws FormException {
             Jenkins jenkins = Jenkins.getInstanceOrNull();
             if (jenkins != null && jenkins.hasPermission(Jenkins.ADMINISTER)) {
+                setAllowHttpConnections(o.getBoolean("allowHttpConnections"));
                 configureJFrogInstances(req, o);
                 save();
                 return super.configure(req, o);
@@ -129,6 +161,13 @@ public class JFrogPlatformBuilder extends GlobalConfiguration {
 
             if (isEmptyUrl(jfrogInstances)) {
                 throw new FormException("Please set the The JFrog Platform URL", "URL");
+            }
+
+            for (JFrogPlatformInstance jfrogInstance : jfrogInstances) {
+                if (isUnsafe(isAllowHttpConnections(), jfrogInstance.getUrl(), jfrogInstance.getArtifactoryUrl(),
+                        jfrogInstance.getDistributionUrl(), jfrogInstance.getXrayUrl())) {
+                    throw new FormException(UNSAFE_HTTP_ERROR, "URL");
+                }
             }
             setJfrogInstances(jfrogInstances);
         }
@@ -193,6 +232,36 @@ public class JFrogPlatformBuilder extends GlobalConfiguration {
             this.jfrogInstances = jfrogInstances;
         }
 
+        /**
+         * Used by Jenkins Jelly for setting values.
+         */
+        @SuppressWarnings("unused")
+        public boolean isAllowHttpConnections() {
+            return this.allowHttpConnections;
+        }
+
+        /**
+         * Used by Jenkins Jelly for setting values.
+         */
+        public void setAllowHttpConnections(boolean allowHttpConnections) {
+            this.allowHttpConnections = allowHttpConnections;
+        }
+    }
+
+    /**
+     * Return true if at least one of the URLs are using an unsafe HTTP protocol and the "Allow HTTP Connection" option is not set.
+     *
+     * @param urls - The URL to check
+     * @return true if the URL is using an unsafe HTTP protocol and the "Allow HTTP Connection" option is not set.
+     */
+    static boolean isUnsafe(boolean allowHttpConnections, String... urls) {
+        for (String url : urls) {
+            //noinspection HttpUrlsUsage
+            if (!allowHttpConnections && StringUtils.startsWith(url, "http://")) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/src/main/resources/io/jenkins/plugins/jfrog/configuration/JFrogPlatformBuilder/global.jelly
+++ b/src/main/resources/io/jenkins/plugins/jfrog/configuration/JFrogPlatformBuilder/global.jelly
@@ -49,5 +49,9 @@
                 </f:block>
             </f:repeatable>
         </f:entry>
+        <f:entry help="/plugin/jfrog/help/JFrogPlatformBuilder/help-allowHttpConnections.html">
+            <f:checkbox title="Allow HTTP Connections" field="allowHttpConnections"
+                        value="${descriptor.allowHttpConnections}"/>
+        </f:entry>
     </f:section>
 </j:jelly>

--- a/src/main/webapp/help/JFrogPlatformBuilder/help-allowHttpConnections.html
+++ b/src/main/webapp/help/JFrogPlatformBuilder/help-allowHttpConnections.html
@@ -1,0 +1,3 @@
+<div>
+    Check to allow HTTP connections with the JFrog platform (Not recommended).
+</div>

--- a/src/main/webapp/help/JFrogPlatformBuilder/help-allowHttpConnections.html
+++ b/src/main/webapp/help/JFrogPlatformBuilder/help-allowHttpConnections.html
@@ -1,3 +1,3 @@
 <div>
-    Check to allow HTTP connections with the JFrog platform (Not recommended).
+    Check to allow HTTP (non HTTPS) connections with the JFrog platform (Not recommended).
 </div>

--- a/src/test/java/io/jenkins/plugins/jfrog/configuration/JFrogPlatformBuilderTest.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/configuration/JFrogPlatformBuilderTest.java
@@ -1,0 +1,24 @@
+package io.jenkins.plugins.jfrog.configuration;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author yahavi
+ **/
+public class JFrogPlatformBuilderTest {
+
+    @SuppressWarnings("HttpUrlsUsage")
+    @Test
+    public void testIsUnsafe() {
+        assertFalse(JFrogPlatformBuilder.isUnsafe(false, "https://acme.jfrog.io"));
+        assertFalse(JFrogPlatformBuilder.isUnsafe(false, "https://acme.jfrog.io"));
+        assertFalse(JFrogPlatformBuilder.isUnsafe(true, "http://acme.jfrog.io"));
+        assertFalse(JFrogPlatformBuilder.isUnsafe(true, "https://acme.jfrog.io", "http://acme.jfrog.io"));
+
+        assertTrue(JFrogPlatformBuilder.isUnsafe(false, "http://acme.jfrog.io"));
+        assertTrue(JFrogPlatformBuilder.isUnsafe(false, "https://acme.jfrog.io", "http://acme.jfrog.io"));
+    }
+}


### PR DESCRIPTION
- [x] This pull request is created in the [jfrog/jenkins-jfrog-plugin](https://github.com/jfrog/jenkins-jfrog-plugin) repository.

Add the `Allow HTTP Connections` checkbox, which allows HTTP connections to the JFrog platform only if it is checked.

On-the-fly check:
![image](https://user-images.githubusercontent.com/11367982/222164692-e32bfbc9-fc92-4fed-a76d-2c4929fe2b34.png)

If the user clicks on Apply or Save, the feature blocks the saving and this error appears:
![image](https://user-images.githubusercontent.com/11367982/222165088-55cb07b0-0116-4536-8a9c-b51c06217949.png)
