### PR TITLE
Support providing the CLI version

### DIFF
--- a/src/main/java/io/jenkins/plugins/jfrog/ArtifactoryInstaller.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/ArtifactoryInstaller.java
@@ -5,16 +5,21 @@ import hudson.FilePath;
 import hudson.model.Node;
 import hudson.model.TaskListener;
 import hudson.tools.ToolInstallation;
+import hudson.util.FormValidation;
 import io.jenkins.plugins.jfrog.configuration.CredentialsConfig;
 import io.jenkins.plugins.jfrog.configuration.JFrogPlatformBuilder;
 import io.jenkins.plugins.jfrog.configuration.JFrogPlatformInstance;
 import io.jenkins.plugins.jfrog.plugins.PluginsUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.jfrog.build.client.Version;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.verb.POST;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.List;
+import java.util.regex.Pattern;
 
 /**
  * Download and install JFrog CLI from a remote artifactory (instead of the default 'releases.jfrog.io')
@@ -23,15 +28,33 @@ import java.util.List;
  */
 @SuppressWarnings("unused")
 public class ArtifactoryInstaller extends BinaryInstaller {
+    private static final Version MIN_CLI_VERSION = new Version("2.6.1");
+    private static final Pattern VERSION_PATTERN = Pattern.compile("^\\d+\\.\\d+\\.\\d+$");
+    static final String BAD_VERSION_PATTERN_ERROR = "Version must be in the form of X.X.X";
+    static final String LOW_VERSION_PATTERN_ERROR = "Provided JFrog CLI version must be at least " + MIN_CLI_VERSION;
 
-    public final String serverId;
-    public final String repository;
+    final String serverId;
+    final String repository;
+    final String version;
 
     @DataBoundConstructor
-    public ArtifactoryInstaller(String id, String repository) {
+    public ArtifactoryInstaller(String id, String repository, String version) {
         super(null);
         this.serverId = id;
-        this.repository = repository;
+        this.repository = StringUtils.trim(repository);
+        this.version = StringUtils.trim(version);
+    }
+
+    public String getServerId() {
+        return serverId;
+    }
+
+    public String getRepository() {
+        return repository;
+    }
+
+    public String getVersion() {
+        return version;
     }
 
     @Override
@@ -41,13 +64,13 @@ public class ArtifactoryInstaller extends BinaryInstaller {
             throw new IOException("Server id '" + serverId + "' doesn't exists.");
         }
         String binaryName = Utils.getJfrogCliBinaryName(!node.createLauncher(log).isUnix());
-        return performJfrogCliInstallation(getToolLocation(tool, node), log, StringUtils.EMPTY, server, repository, binaryName);
+        return performJfrogCliInstallation(getToolLocation(tool, node), log, version, server, repository, binaryName);
     }
 
     /**
      * Look for all configured server ids and return the specific one matched the given id.
      */
-    private JFrogPlatformInstance getSpecificServer(String id) {
+    JFrogPlatformInstance getSpecificServer(String id) {
         List<JFrogPlatformInstance> jfrogInstances = JFrogPlatformBuilder.getJFrogPlatformInstances();
         if (jfrogInstances != null && jfrogInstances.size() > 0) {
             for (JFrogPlatformInstance jfrogPlatformInstance : jfrogInstances) {
@@ -64,8 +87,28 @@ public class ArtifactoryInstaller extends BinaryInstaller {
         return null;
     }
 
+    /**
+     * Make on-the-fly validation that the provided CLI version is empty or at least 2.6.1.
+     *
+     * @param version - Requested JFrog CLI version
+     * @return the validation results.
+     */
+    static FormValidation checkCliVersion(@QueryParameter String version) {
+        if (StringUtils.isBlank(version)) {
+            return FormValidation.ok();
+        }
+        if (!VERSION_PATTERN.matcher(version).matches()) {
+            return FormValidation.error(BAD_VERSION_PATTERN_ERROR);
+        }
+        if (!new Version(version).isAtLeast(MIN_CLI_VERSION)) {
+            return FormValidation.error(LOW_VERSION_PATTERN_ERROR);
+        }
+        return FormValidation.ok();
+    }
+
     @Extension
     public static final class DescriptorImpl extends BinaryInstaller.DescriptorImpl<ArtifactoryInstaller> {
+
         @Nonnull
         public String getDisplayName() {
             return "Install from Artifactory";
@@ -83,6 +126,21 @@ public class ArtifactoryInstaller extends BinaryInstaller {
          */
         public List<JFrogPlatformInstance> getServerIds() {
             return JFrogPlatformBuilder.getJFrogPlatformInstances();
+        }
+
+        @POST
+        @SuppressWarnings("unused")
+        public FormValidation doCheckRepository(@QueryParameter String repository) {
+            if (StringUtils.isBlank(repository)) {
+                return FormValidation.error("Required");
+            }
+            return FormValidation.ok();
+        }
+
+        @POST
+        @SuppressWarnings("unused")
+        public FormValidation doCheckVersion(@QueryParameter String version) {
+            return checkCliVersion(version);
         }
     }
 }

--- a/src/main/java/io/jenkins/plugins/jfrog/ArtifactoryInstaller.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/ArtifactoryInstaller.java
@@ -31,7 +31,7 @@ public class ArtifactoryInstaller extends BinaryInstaller {
     private static final Version MIN_CLI_VERSION = new Version("2.6.1");
     private static final Pattern VERSION_PATTERN = Pattern.compile("^\\d+\\.\\d+\\.\\d+$");
     static final String BAD_VERSION_PATTERN_ERROR = "Version must be in the form of X.X.X";
-    static final String LOW_VERSION_PATTERN_ERROR = "Provided JFrog CLI version must be at least " + MIN_CLI_VERSION;
+    static final String LOW_VERSION_PATTERN_ERROR = "The provided JFrog CLI version must be at least " + MIN_CLI_VERSION;
 
     final String serverId;
     final String repository;
@@ -93,7 +93,7 @@ public class ArtifactoryInstaller extends BinaryInstaller {
      * @param version - Requested JFrog CLI version
      * @return the validation results.
      */
-    static FormValidation checkCliVersion(@QueryParameter String version) {
+    static FormValidation validateCliVersion(@QueryParameter String version) {
         if (StringUtils.isBlank(version)) {
             return FormValidation.ok();
         }
@@ -108,7 +108,6 @@ public class ArtifactoryInstaller extends BinaryInstaller {
 
     @Extension
     public static final class DescriptorImpl extends BinaryInstaller.DescriptorImpl<ArtifactoryInstaller> {
-
         @Nonnull
         public String getDisplayName() {
             return "Install from Artifactory";
@@ -140,7 +139,7 @@ public class ArtifactoryInstaller extends BinaryInstaller {
         @POST
         @SuppressWarnings("unused")
         public FormValidation doCheckVersion(@QueryParameter String version) {
-            return checkCliVersion(version);
+            return validateCliVersion(version);
         }
     }
 }

--- a/src/main/java/io/jenkins/plugins/jfrog/ReleasesInstaller.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/ReleasesInstaller.java
@@ -1,46 +1,38 @@
 package io.jenkins.plugins.jfrog;
 
 import hudson.Extension;
-import hudson.FilePath;
-import hudson.model.Node;
-import hudson.model.TaskListener;
 import hudson.tools.ToolInstallation;
+import hudson.util.FormValidation;
 import io.jenkins.plugins.jfrog.configuration.Credentials;
 import io.jenkins.plugins.jfrog.configuration.CredentialsConfig;
 import io.jenkins.plugins.jfrog.configuration.JFrogPlatformInstance;
 import org.apache.commons.lang3.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.verb.POST;
 
 import javax.annotation.Nonnull;
-import java.io.IOException;
 
 /**
  * Download and install Jfrog CLI from 'releases.jfrog.io'.
  *
  * @author gail
  */
-public class ReleasesInstaller extends BinaryInstaller {
-    public final String id;
+public class ReleasesInstaller extends ArtifactoryInstaller {
     public static final String RELEASES_ARTIFACTORY_URL = "https://releases.jfrog.io/artifactory";
     public static final String REPOSITORY = "jfrog-cli";
 
     @DataBoundConstructor
-    public ReleasesInstaller(String id) {
-        super(null);
-        this.id = id;
-    }
-
-    @Override
-    public FilePath performInstallation(ToolInstallation tool, Node node, TaskListener log) throws IOException, InterruptedException {
-        JFrogPlatformInstance instance = createReleasesPlatformInstance();
-        String binaryName = Utils.getJfrogCliBinaryName(!node.createLauncher(log).isUnix());
-        return performJfrogCliInstallation(getToolLocation(tool, node), log, id, instance, REPOSITORY, binaryName);
+    public ReleasesInstaller(String version) {
+        super("", REPOSITORY, version);
     }
 
     /**
      * @return The JFrogPlatformInstance matches 'Releases.jfrog.io' with only the relevant Artifactory URL and no credentials.
      */
-    private JFrogPlatformInstance createReleasesPlatformInstance() {
+
+    @Override
+    JFrogPlatformInstance getSpecificServer(String id) {
         CredentialsConfig emptyCred = new CredentialsConfig(StringUtils.EMPTY, Credentials.EMPTY_CREDENTIALS);
         return new JFrogPlatformInstance(StringUtils.EMPTY, StringUtils.EMPTY, emptyCred, RELEASES_ARTIFACTORY_URL, StringUtils.EMPTY, StringUtils.EMPTY);
     }
@@ -56,6 +48,12 @@ public class ReleasesInstaller extends BinaryInstaller {
         @Override
         public boolean isApplicable(Class<? extends ToolInstallation> toolType) {
             return toolType == JfrogInstallation.class;
+        }
+
+        @POST
+        @SuppressWarnings("unused")
+        public FormValidation doCheckVersion(@QueryParameter String version) {
+            return checkCliVersion(version);
         }
     }
 }

--- a/src/main/java/io/jenkins/plugins/jfrog/ReleasesInstaller.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/ReleasesInstaller.java
@@ -53,7 +53,7 @@ public class ReleasesInstaller extends ArtifactoryInstaller {
         @POST
         @SuppressWarnings("unused")
         public FormValidation doCheckVersion(@QueryParameter String version) {
-            return checkCliVersion(version);
+            return validateCliVersion(version);
         }
     }
 }

--- a/src/main/resources/io/jenkins/plugins/jfrog/ArtifactoryInstaller/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/jfrog/ArtifactoryInstaller/config.jelly
@@ -1,13 +1,18 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
-    <f:entry title="${%Server ID}" field="serverId">
+    <f:entry title="${%Server ID}" field="serverId" help="/plugin/jfrog/help/ArtifactoryInstaller/help-serverId.html">
         <select name="id">
             <j:forEach var="server" items="${descriptor.serverIds}">
                 <f:option value="${server.id}" selected="${server.id==instance.id}">${server.id}</f:option>
             </j:forEach>
         </select>
-        <f:entry title="${%Remote JFrog CLI repository}" field="repository">
-            <f:textbox/>
-        </f:entry>
+    </f:entry>
+    <f:entry title="${%Remote JFrog CLI repository}" field="repository"
+             help="/plugin/jfrog/help/ArtifactoryInstaller/help-repository.html">
+        <f:textbox/>
+    </f:entry>
+    <f:entry title="${%Version}" field="version" description="(Leave empty to install the latest version)"
+             help="/plugin/jfrog/help/ArtifactoryInstaller/help-version.html">
+        <f:textbox/>
     </f:entry>
 </j:jelly>

--- a/src/main/resources/io/jenkins/plugins/jfrog/ReleasesInstaller/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/jfrog/ReleasesInstaller/config.jelly
@@ -1,7 +1,7 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
-    <f:entry title="Version" field="id">
-        <f:entry title="(Leave empty to get the latest version)"/>
+    <f:entry title="${%Version}" field="version" description="(Leave empty to install the latest version)"
+             help="/plugin/jfrog/help/ArtifactoryInstaller/help-version.html">
         <f:textbox/>
     </f:entry>
 </j:jelly>

--- a/src/main/webapp/help/ArtifactoryInstaller/help-repository.html
+++ b/src/main/webapp/help/ArtifactoryInstaller/help-repository.html
@@ -1,0 +1,3 @@
+<div>
+    Remote repository in Artifactory pointing to https://releases.jfrog.io/artifactory/jfrog-cli
+</div>

--- a/src/main/webapp/help/ArtifactoryInstaller/help-serverId.html
+++ b/src/main/webapp/help/ArtifactoryInstaller/help-serverId.html
@@ -1,0 +1,3 @@
+<div>
+    Server ID of your JFrog instance, which configured in Manage Jenkins | Configure System.
+</div>

--- a/src/main/webapp/help/ArtifactoryInstaller/help-serverId.html
+++ b/src/main/webapp/help/ArtifactoryInstaller/help-serverId.html
@@ -1,3 +1,3 @@
 <div>
-    Server ID of your JFrog instance, which configured in Manage Jenkins | Configure System.
+    Server ID of your JFrog instance, which is configured in 'Manage Jenkins | Configure System'.
 </div>

--- a/src/main/webapp/help/ArtifactoryInstaller/help-version.html
+++ b/src/main/webapp/help/ArtifactoryInstaller/help-version.html
@@ -1,0 +1,3 @@
+<div>
+    Select JFrog CLI version or leave empty to download the latest. Required at least 2.6.1.
+</div>

--- a/src/test/java/io/jenkins/plugins/jfrog/ArtifactoryInstallerCheckCliVersionTest.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/ArtifactoryInstallerCheckCliVersionTest.java
@@ -43,7 +43,7 @@ public class ArtifactoryInstallerCheckCliVersionTest {
     }
 
     @Test
-    public void testCheckCliVersion() {
-        assertEquals(expectedResult, checkCliVersion(inputVersion).getMessage());
+    public void testValidateCliVersion() {
+        assertEquals(expectedResult, validateCliVersion(inputVersion).getMessage());
     }
 }

--- a/src/test/java/io/jenkins/plugins/jfrog/ArtifactoryInstallerCheckCliVersionTest.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/ArtifactoryInstallerCheckCliVersionTest.java
@@ -1,0 +1,49 @@
+package io.jenkins.plugins.jfrog;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static io.jenkins.plugins.jfrog.ArtifactoryInstaller.*;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author yahavi
+ **/
+@RunWith(Parameterized.class)
+public class ArtifactoryInstallerCheckCliVersionTest {
+    private final String inputVersion;
+    private final String expectedResult;
+
+    public ArtifactoryInstallerCheckCliVersionTest(String inputVersion, String expectedResult) {
+        this.inputVersion = inputVersion;
+        this.expectedResult = expectedResult;
+    }
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> dataProvider() {
+        return Arrays.asList(
+                // Positive tests
+                new Object[]{"", null},
+                new Object[]{"2.6.1", null},
+                new Object[]{"2.7.0", null},
+
+                // Bad syntax
+                new Object[]{"bad version", BAD_VERSION_PATTERN_ERROR},
+                new Object[]{"1.2", BAD_VERSION_PATTERN_ERROR},
+                new Object[]{"1.2.a", BAD_VERSION_PATTERN_ERROR},
+
+                // Versions below minimum
+                new Object[]{"2.5.9", LOW_VERSION_PATTERN_ERROR},
+                new Object[]{"2.6.0", LOW_VERSION_PATTERN_ERROR}
+        );
+    }
+
+    @Test
+    public void testCheckCliVersion() {
+        assertEquals(expectedResult, checkCliVersion(inputVersion).getMessage());
+    }
+}

--- a/src/test/java/io/jenkins/plugins/jfrog/integration/PipelineTestBase.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/integration/PipelineTestBase.java
@@ -288,7 +288,7 @@ public class PipelineTestBase {
     }
 
     public static void configureJfrogCliFromArtifactory(String toolName, String serverId, String repo, Boolean override) throws Exception {
-        configureJfrogCliTool(toolName, new ArtifactoryInstaller(serverId, repo), override);
+        configureJfrogCliTool(toolName, new ArtifactoryInstaller(serverId, repo, ""), override);
     }
 
     /**
@@ -297,7 +297,6 @@ public class PipelineTestBase {
      * @param toolName  the tool name.
      * @param installer the tool installer (Releases or Artifactory).
      * @param override  The tool will override pre-configured ones and be set if true, otherwise it will be added to the installation array.
-     * @return the new tool's JfrogInstallation.
      * @throws IOException failed to configure the new tool.
      */
     public static void configureJfrogCliTool(String toolName, BinaryInstaller installer, Boolean override) throws Exception {
@@ -317,6 +316,5 @@ public class PipelineTestBase {
         }
         JfrogInstallation[] installations = installationsArrayList.toArray(new JfrogInstallation[0]);
         Jenkins.get().getDescriptorByType(JfrogInstallation.DescriptorImpl.class).setInstallations(installations);
-        return;
     }
 }


### PR DESCRIPTION
- [x] This pull request is created in the [jfrog/jenkins-jfrog-plugin](https://github.com/jfrog/jenkins-jfrog-plugin) repository.

Allow providing the JFrog CLI version in the ArtifactoryInstaller and in the ReleasesInstaller.
* Add help tags
* Add form validators

![image](https://user-images.githubusercontent.com/11367982/222710758-3c7b9ead-845d-45b7-a385-f4a6f4dd2456.png)

![image](https://user-images.githubusercontent.com/11367982/222710834-2210a47f-fbcd-4905-91f9-5eb2e0027c3c.png)
