### PR TITLE
Add support for Jenkins Configuration as Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ To configure this plugin on Jenkins Configuration as Code, add the following sec
       jFrogPlatformBuilder:
         jfrogInstances:
           - serverId: "acme"
-            platformUrl: "https://acme.jfrog.io"
+            url: "https://acme.jfrog.io"
             artifactoryUrl: "https://acme.jfrog.io/artifactory"
             distributionUrl: "https://acme.jfrog.io/distribution"
             xrayUrl: "https://acme.jfrog.io/xray"

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 - [Using JFrog CLI in your pipeline jobs](#using-jfrog-cli-in-your-pipeline-jobs)
     - [Setting the build name and build number](#setting-the-build-name-and-the-build-number)
     - [Using multiple JFrog Platform instances](#using-multiple-jfrog-platform-instances)
+- [Jenkins Configuration as Code](#jenkins-configuration-as-code)
 - [Examples](#examples)
 - [Contributions](#contributions)
 
@@ -139,6 +140,55 @@ the server ID you configured for the instance. For example:
 jf 'rt u test-file my-repo –-server-id server-1'
 jf 'rt u test-file my-repo –-server-id server-2'
 ```
+
+## Jenkins Configuration as Code
+
+To configure this plugin on Jenkins Configuration as Code, add the following sections to the jenkins.yaml:
+
+1. Configure connection details to the JFrog platform
+    ```yaml
+    unclassified:
+      jFrogPlatformBuilder:
+        jfrogInstances:
+          - serverId: "acme"
+            platformUrl: "https://acme.jfrog.io"
+            artifactoryUrl: "https://acme.jfrog.io/artifactory"
+            distributionUrl: "https://acme.jfrog.io/distribution"
+            xrayUrl: "https://acme.jfrog.io/xray"
+            credentialsConfig:
+              credentialsId: "acme-secret-recipe"
+    ```
+2. Add JFrog CLI tool using one of the following methods:
+
+* [Automatic installation from release.jfrog.io](#automatic-installation-from-releasejfrogio):
+    ```yaml
+    tool:
+      jfrog:
+        installations:
+          - name: "jfrog-cli"
+    ```
+
+* [Automatic installation from Artifactory](#automatic-installation-from-artifactory):
+    ```yaml
+    tool:
+      jfrog:
+        installations:
+          - name: "jfrog-cli"
+            properties:
+              - installSource:
+                  installers:
+                    - artifactoryInstaller:
+                        repository: "jfrog-cli-remote"
+    ```
+
+* [Manual installation](#manual-installation):
+    ```yaml
+    tool:
+      jfrog:
+        installations:
+          - name: "jfrog-cli"
+            home: "/path/to/jfrog/cli/dir/"
+    ```
 
 ## Examples
 

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.jenkins</groupId>
+            <artifactId>configuration-as-code</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jfrog.buildinfo</groupId>
             <artifactId>build-info-extractor</artifactId>
             <version>${buildinfo.version}</version>

--- a/src/main/java/io/jenkins/plugins/jfrog/ArtifactoryInstaller.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/ArtifactoryInstaller.java
@@ -38,9 +38,9 @@ public class ArtifactoryInstaller extends BinaryInstaller {
     final String version;
 
     @DataBoundConstructor
-    public ArtifactoryInstaller(String id, String repository, String version) {
+    public ArtifactoryInstaller(String serverId, String repository, String version) {
         super(null);
-        this.serverId = id;
+        this.serverId = serverId;
         this.repository = StringUtils.trim(repository);
         this.version = StringUtils.trim(version);
     }

--- a/src/main/java/io/jenkins/plugins/jfrog/ArtifactoryInstaller.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/ArtifactoryInstaller.java
@@ -28,9 +28,9 @@ public class ArtifactoryInstaller extends BinaryInstaller {
     public final String repository;
 
     @DataBoundConstructor
-    public ArtifactoryInstaller(String id, String repository) {
+    public ArtifactoryInstaller(String serverId, String repository) {
         super(null);
-        this.serverId = id;
+        this.serverId = serverId;
         this.repository = repository;
     }
 

--- a/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
@@ -182,7 +182,7 @@ public class JfStep<T> extends Builder implements SimpleBuildStep {
             builder.addMasked("--password=" + credentials.getPassword());
         }
         // Add URLs
-        builder.add("--url=" + jfrogPlatformInstance.getUrl());
+        builder.add("--url=" + jfrogPlatformInstance.getPlatformUrl());
         builder.add("--artifactory-url=" + jfrogPlatformInstance.getArtifactoryUrl());
         builder.add("--distribution-url=" + jfrogPlatformInstance.getDistributionUrl());
         builder.add("--xray-url=" + jfrogPlatformInstance.getXrayUrl());

--- a/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
@@ -182,7 +182,7 @@ public class JfStep<T> extends Builder implements SimpleBuildStep {
             builder.addMasked("--password=" + credentials.getPassword());
         }
         // Add URLs
-        builder.add("--url=" + jfrogPlatformInstance.getPlatformUrl());
+        builder.add("--url=" + jfrogPlatformInstance.getUrl());
         builder.add("--artifactory-url=" + jfrogPlatformInstance.getArtifactoryUrl());
         builder.add("--distribution-url=" + jfrogPlatformInstance.getDistributionUrl());
         builder.add("--xray-url=" + jfrogPlatformInstance.getXrayUrl());

--- a/src/main/java/io/jenkins/plugins/jfrog/configuration/JFrogPlatformBuilder.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/configuration/JFrogPlatformBuilder.java
@@ -92,7 +92,7 @@ public class JFrogPlatformBuilder extends GlobalConfiguration {
         public FormValidation doCheckUrl(@QueryParameter String value) {
             Jenkins.get().checkPermission(Jenkins.ADMINISTER);
             if (StringUtils.isBlank(value)) {
-                return FormValidation.error("Please set platform URL");
+                return FormValidation.error("Please set the JFrog Platform URL");
             }
             return checkUrlInForm(value);
         }
@@ -160,7 +160,7 @@ public class JFrogPlatformBuilder extends GlobalConfiguration {
             }
 
             if (isEmptyUrl(jfrogInstances)) {
-                throw new FormException("Please set the The JFrog Platform URL", "URL");
+                throw new FormException("Please set the JFrog Platform URL", "URL");
             }
 
             for (JFrogPlatformInstance jfrogInstance : jfrogInstances) {

--- a/src/main/java/io/jenkins/plugins/jfrog/configuration/JFrogPlatformBuilder.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/configuration/JFrogPlatformBuilder.java
@@ -89,7 +89,7 @@ public class JFrogPlatformBuilder extends GlobalConfiguration {
 
         @POST
         @SuppressWarnings("unused")
-        public FormValidation doCheckPlatformUrl(@QueryParameter String value) {
+        public FormValidation doCheckUrl(@QueryParameter String value) {
             Jenkins.get().checkPermission(Jenkins.ADMINISTER);
             if (StringUtils.isBlank(value)) {
                 return FormValidation.error("Please set platform URL");
@@ -119,7 +119,7 @@ public class JFrogPlatformBuilder extends GlobalConfiguration {
         }
 
         /**
-         * Performs on-the-fly validation of the form fields 'platformUrl', 'artifactoryUrl', 'distributionUrl', or 'xrayUrl'.
+         * Performs on-the-fly validation of the form fields 'url', 'artifactoryUrl', 'distributionUrl', or 'xrayUrl'.
          *
          * @param value the URL value that the user has typed.
          * @return the outcome of the validation. This is sent to the browser.
@@ -211,7 +211,7 @@ public class JFrogPlatformBuilder extends GlobalConfiguration {
                 return false;
             }
             for (JFrogPlatformInstance instance : jfrogInstances) {
-                if (StringUtils.isBlank(instance.getPlatformUrl())) {
+                if (StringUtils.isBlank(instance.getUrl())) {
                     return true;
                 }
             }

--- a/src/main/java/io/jenkins/plugins/jfrog/configuration/JFrogPlatformBuilder.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/configuration/JFrogPlatformBuilder.java
@@ -172,7 +172,7 @@ public class JFrogPlatformBuilder extends GlobalConfiguration {
                 return false;
             }
             for (JFrogPlatformInstance instance : jfrogInstances) {
-                if (StringUtils.isBlank(instance.getUrl())) {
+                if (StringUtils.isBlank(instance.getPlatformUrl())) {
                     return true;
                 }
             }

--- a/src/main/java/io/jenkins/plugins/jfrog/configuration/JFrogPlatformInstance.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/configuration/JFrogPlatformInstance.java
@@ -10,7 +10,7 @@ import java.util.List;
  * Represents an instance of jenkins JFrog instance configuration page.
  */
 public class JFrogPlatformInstance implements Serializable {
-    private String platformUrl;
+    private String url;
     private String artifactoryUrl;
     private String distributionUrl;
     private String xrayUrl;
@@ -18,13 +18,13 @@ public class JFrogPlatformInstance implements Serializable {
     private CredentialsConfig credentialsConfig;
 
     @DataBoundConstructor
-    public JFrogPlatformInstance(String serverId, String platformUrl, CredentialsConfig credentialsConfig, String artifactoryUrl, String distributionUrl, String xrayUrl) {
+    public JFrogPlatformInstance(String serverId, String url, CredentialsConfig credentialsConfig, String artifactoryUrl, String distributionUrl, String xrayUrl) {
         this.id = serverId;
-        this.platformUrl = StringUtils.isNotEmpty(platformUrl) ? StringUtils.removeEnd(platformUrl, "/") : null;
+        this.url = StringUtils.isNotEmpty(url) ? StringUtils.removeEnd(url, "/") : null;
         this.credentialsConfig = credentialsConfig;
-        this.artifactoryUrl = addUrlSuffix(artifactoryUrl, this.platformUrl, "artifactory");
-        this.distributionUrl = addUrlSuffix(distributionUrl, this.platformUrl, "distribution");
-        this.xrayUrl = addUrlSuffix(xrayUrl, this.platformUrl, "xray");
+        this.artifactoryUrl = addUrlSuffix(artifactoryUrl, this.url, "artifactory");
+        this.distributionUrl = addUrlSuffix(distributionUrl, this.url, "distribution");
+        this.xrayUrl = addUrlSuffix(xrayUrl, this.url, "xray");
     }
 
     public CredentialsConfig getCredentialsConfig() {
@@ -54,14 +54,14 @@ public class JFrogPlatformInstance implements Serializable {
 
     // Required by external plugins (JCasC).
     @SuppressWarnings("unused")
-    public String getPlatformUrl() {
-        return platformUrl;
+    public String getUrl() {
+        return url;
     }
 
     // Required by external plugins (JCasC).
     @SuppressWarnings("unused")
-    public void setPlatformUrl(String platformUrl) {
-        this.platformUrl = platformUrl;
+    public void setUrl(String url) {
+        this.url = url;
     }
 
     // Required by external plugins (JCasC).

--- a/src/main/java/io/jenkins/plugins/jfrog/configuration/JFrogPlatformInstance.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/configuration/JFrogPlatformInstance.java
@@ -10,7 +10,7 @@ import java.util.List;
  * Represents an instance of jenkins JFrog instance configuration page.
  */
 public class JFrogPlatformInstance implements Serializable {
-    private String url;
+    private String platformUrl;
     private String artifactoryUrl;
     private String distributionUrl;
     private String xrayUrl;
@@ -20,11 +20,11 @@ public class JFrogPlatformInstance implements Serializable {
     @DataBoundConstructor
     public JFrogPlatformInstance(String serverId, String platformUrl, CredentialsConfig credentialsConfig, String artifactoryUrl, String distributionUrl, String xrayUrl) {
         this.id = serverId;
-        this.url = StringUtils.isNotEmpty(platformUrl) ? StringUtils.removeEnd(platformUrl, "/") : null;
+        this.platformUrl = StringUtils.isNotEmpty(platformUrl) ? StringUtils.removeEnd(platformUrl, "/") : null;
         this.credentialsConfig = credentialsConfig;
-        this.artifactoryUrl = addUrlSuffix(artifactoryUrl, this.url, "artifactory");
-        this.distributionUrl = addUrlSuffix(distributionUrl, this.url, "distribution");
-        this.xrayUrl = addUrlSuffix(xrayUrl, this.url, "xray");
+        this.artifactoryUrl = addUrlSuffix(artifactoryUrl, this.platformUrl, "artifactory");
+        this.distributionUrl = addUrlSuffix(distributionUrl, this.platformUrl, "distribution");
+        this.xrayUrl = addUrlSuffix(xrayUrl, this.platformUrl, "xray");
     }
 
     public CredentialsConfig getCredentialsConfig() {
@@ -54,14 +54,14 @@ public class JFrogPlatformInstance implements Serializable {
 
     // Required by external plugins (JCasC).
     @SuppressWarnings("unused")
-    public String getUrl() {
-        return url;
+    public String getPlatformUrl() {
+        return platformUrl;
     }
 
     // Required by external plugins (JCasC).
     @SuppressWarnings("unused")
-    public void setUrl(String url) {
-        this.url = url;
+    public void setPlatformUrl(String platformUrl) {
+        this.platformUrl = platformUrl;
     }
 
     // Required by external plugins (JCasC).

--- a/src/main/resources/io/jenkins/plugins/jfrog/ArtifactoryInstaller/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/jfrog/ArtifactoryInstaller/config.jelly
@@ -3,7 +3,7 @@
     <f:entry title="${%Server ID}" field="serverId" help="/plugin/jfrog/help/ArtifactoryInstaller/help-serverId.html">
         <select name="id">
             <j:forEach var="server" items="${descriptor.serverIds}">
-                <f:option value="${server.id}" selected="${server.id==instance.id}">${server.id}</f:option>
+                <f:option value="${server.serverId}" selected="${server.serverId==instance.serverId}">${server.serverId}</f:option>
             </j:forEach>
         </select>
     </f:entry>

--- a/src/main/resources/io/jenkins/plugins/jfrog/configuration/JFrogPlatformBuilder/global.jelly
+++ b/src/main/resources/io/jenkins/plugins/jfrog/configuration/JFrogPlatformBuilder/global.jelly
@@ -13,8 +13,8 @@
                     <f:entry title="Server ID">
                         <f:textbox field="serverId" value="${instance.serverId}"/>
                     </f:entry>
-                    <f:entry title="JFrog Platform URL" field="platformUrl">
-                        <f:textbox field="platformUrl" value="${instance.url}"/>
+                    <f:entry title="JFrog Platform URL" field="url">
+                        <f:textbox field="url" value="${instance.url}"/>
                     </f:entry>
                     <f:section name="credentialsConfig">
                         <f:block>


### PR DESCRIPTION
- [x] This pull request is created in the [jfrog/jenkins-jfrog-plugin](https://github.com/jfrog/jenkins-jfrog-plugin) repository.

Fix #31
Fix #22

* The constructor argument names must match the class variable names. Otherwise the following issues may appear during configuration export:
> io.jenkins.plugins.jfrog.configuration.JFrogPlatformBuilder$DescriptorImpl#jfrogInstances: io.jenkins.plugins.casc.ConfiguratorException: Can't read attribute 'platformUrl' from io.jenkins.plugins.jfrog.configuration.JFrogPlatformInstance@2daa7334

* Add JCasC instructions - https://github.com/yahavi/jenkins-jfrog-plugin/tree/fix-jcasc#jenkins-configuration-as-code