### PR TITLE
Support HTTP/S proxy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,12 @@
             <version>4.5.3</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.1.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <dependencyManagement>
         <dependencies>

--- a/src/main/java/io/jenkins/plugins/jfrog/BinaryInstaller.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/BinaryInstaller.java
@@ -12,6 +12,7 @@ import io.jenkins.plugins.jfrog.configuration.JFrogPlatformInstance;
 import jenkins.MasterToSlaveFileCallable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.Header;
+import org.jfrog.build.client.ProxyConfiguration;
 import org.jfrog.build.extractor.clientConfiguration.client.artifactory.ArtifactoryManager;
 
 import java.io.File;
@@ -20,6 +21,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import static io.jenkins.plugins.jfrog.Utils.createProxyConfiguration;
 import static org.jfrog.build.client.DownloadResponse.SHA256_HEADER_NAME;
 
 
@@ -90,6 +92,10 @@ public abstract class BinaryInstaller extends ToolInstaller {
         // Downloading binary from Artifactory
         try (ArtifactoryManager manager = new ArtifactoryManager(instance.getArtifactoryUrl(), Secret.toString(instance.getCredentialsConfig().getUsername()),
                 Secret.toString(instance.getCredentialsConfig().getPassword()), Secret.toString(instance.getCredentialsConfig().getAccessToken()), buildInfoLog)) {
+            ProxyConfiguration proxyConfiguration = createProxyConfiguration();
+            if (proxyConfiguration != null) {
+                manager.setProxyConfiguration(proxyConfiguration);
+            }
             // Getting updated cli binary's sha256 form Artifactory.
             String artifactorySha256 = getArtifactSha256(manager, cliUrlSuffix);
             if (shouldDownloadTool(toolLocation, artifactorySha256)) {

--- a/src/main/java/io/jenkins/plugins/jfrog/CliEnvConfigurator.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/CliEnvConfigurator.java
@@ -1,0 +1,74 @@
+package io.jenkins.plugins.jfrog;
+
+import hudson.EnvVars;
+import org.apache.commons.lang3.StringUtils;
+import org.jfrog.build.client.ProxyConfiguration;
+
+import static io.jenkins.plugins.jfrog.Utils.createProxyConfiguration;
+
+/**
+ * Configures JFrog CLI environment variables for the job.
+ *
+ * @author yahavi
+ **/
+public class CliEnvConfigurator {
+    static final String JFROG_CLI_DEFAULT_EXCLUSIONS = "*password*;*psw*;*secret*;*key*;*token*;*auth*";
+    static final String JFROG_CLI_HOME_DIR = "JFROG_CLI_HOME_DIR";
+    static final String JFROG_CLI_BUILD_NAME = "JFROG_CLI_BUILD_NAME";
+    static final String JFROG_CLI_BUILD_NUMBER = "JFROG_CLI_BUILD_NUMBER";
+    static final String JFROG_CLI_BUILD_URL = "JFROG_CLI_BUILD_URL";
+    static final String HTTPS_PROXY_ENV = "HTTPS_PROXY";
+    static final String HTTP_PROXY_ENV = "HTTP_PROXY";
+    static final String JFROG_CLI_ENV_EXCLUDE = "JFROG_CLI_ENV_EXCLUDE";
+
+    /**
+     * Configure the JFrog CLI environment variables, according to the input job's env.
+     *
+     * @param env              - Job's environment variables
+     * @param jfrogHomeTempDir - Calculated JFrog CLI home dir
+     */
+    static void configureCliEnv(EnvVars env, String jfrogHomeTempDir) {
+        // Setting Jenkins job name as the default build-info name
+        env.putIfAbsent(JFROG_CLI_BUILD_NAME, env.get("JOB_NAME"));
+        // Setting Jenkins build number as the default build-info number
+        env.putIfAbsent(JFROG_CLI_BUILD_NUMBER, env.get("BUILD_NUMBER"));
+        // Setting the specific build URL
+        env.putIfAbsent(JFROG_CLI_BUILD_URL, env.get("BUILD_URL"));
+        // Set up a temporary Jfrog CLI home directory for a specific run
+        env.put(JFROG_CLI_HOME_DIR, jfrogHomeTempDir);
+        if (StringUtils.isAllBlank(env.get(HTTP_PROXY_ENV), env.get(HTTPS_PROXY_ENV))) {
+            // Set up HTTP/S proxy
+            setupProxy(env);
+        }
+    }
+
+    @SuppressWarnings("HttpUrlsUsage")
+    private static void setupProxy(EnvVars env) {
+        ProxyConfiguration proxyConfiguration = createProxyConfiguration();
+        if (proxyConfiguration == null) {
+            // No proxy configured
+            return;
+        }
+
+        // Add HTTP or HTTPS protocol according to the port
+        String proxyUrl = proxyConfiguration.port == 443 ? "https://" : "http://";
+        if (!StringUtils.isAnyBlank(proxyConfiguration.username, proxyConfiguration.password)) {
+            // Add username and password, if provided
+            proxyUrl += proxyConfiguration.username + ":" + proxyConfiguration.password + "@";
+            excludeProxyEnvFromPublishing(env);
+        }
+        proxyUrl += proxyConfiguration.host + ":" + proxyConfiguration.port;
+        env.put(HTTP_PROXY_ENV, proxyUrl);
+        env.put(HTTPS_PROXY_ENV, proxyUrl);
+    }
+
+    /**
+     * Exclude the HTTP_PROXY and HTTPS_PROXY environment variable from build-info if they contain credentials.
+     *
+     * @param env - Job's environment variables
+     */
+    private static void excludeProxyEnvFromPublishing(EnvVars env) {
+        String jfrogCliEnvExclude = env.getOrDefault(JFROG_CLI_ENV_EXCLUDE, JFROG_CLI_DEFAULT_EXCLUSIONS);
+        env.put(JFROG_CLI_ENV_EXCLUDE, String.join(";", jfrogCliEnvExclude, HTTP_PROXY_ENV, HTTPS_PROXY_ENV));
+    }
+}

--- a/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
@@ -37,10 +37,6 @@ import static io.jenkins.plugins.jfrog.JfrogInstallation.JFROG_BINARY_PATH;
 @SuppressWarnings("unused")
 public class JfStep<T> extends Builder implements SimpleBuildStep {
     static final String STEP_NAME = "jf";
-    static final String JFROG_CLI_HOME_DIR = "JFROG_CLI_HOME_DIR";
-    public static final String JFROG_CLI_BUILD_NAME = "JFROG_CLI_BUILD_NAME";
-    public static final String JFROG_CLI_BUILD_NUMBER = "JFROG_CLI_BUILD_NUMBER";
-    public static final String JFROG_CLI_BUILD_URL = "JFROG_CLI_BUILD_URL";
     protected String args;
 
     @DataBoundConstructor
@@ -111,17 +107,8 @@ public class JfStep<T> extends Builder implements SimpleBuildStep {
      * @throws IOException          in case of any I/O error, or we failed to run the 'jf' command
      */
     public Launcher.ProcStarter setupJFrogEnvironment(Run<?, ?> run, EnvVars env, Launcher launcher, TaskListener listener, FilePath workspace, String jfrogBinaryPath, boolean isWindows) throws IOException, InterruptedException {
-        // Set relevant environment variables.
-        // Setting Jenkins job name as the default build-info name.
-        env.putIfAbsent(JFROG_CLI_BUILD_NAME, env.get("JOB_NAME"));
-        // Setting Jenkins build number as the default build-info number.
-        env.putIfAbsent(JFROG_CLI_BUILD_NUMBER, env.get("BUILD_NUMBER"));
-        // Setting the specific build URL.
-        env.putIfAbsent(JFROG_CLI_BUILD_URL, env.get("BUILD_URL"));
-        // Set up a temporary Jfrog CLI home directory for a specific run.
         FilePath jfrogHomeTempDir = Utils.createAndGetJfrogCliHomeTempDir(workspace, String.valueOf(run.getNumber()));
-        env.put(JFROG_CLI_HOME_DIR, jfrogHomeTempDir.getRemote());
-
+        CliEnvConfigurator.configureCliEnv(env, jfrogHomeTempDir.getRemote());
         Launcher.ProcStarter jfLauncher = launcher.launch().envs(env).pwd(workspace).stdout(listener);
         // Configure all servers, skip if all server ids have already been configured.
         if (shouldConfig(jfrogHomeTempDir)) {

--- a/src/main/java/io/jenkins/plugins/jfrog/Utils.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/Utils.java
@@ -3,8 +3,11 @@ package io.jenkins.plugins.jfrog;
 import hudson.FilePath;
 import hudson.model.Job;
 import hudson.model.TaskListener;
+import hudson.util.Secret;
+import jenkins.model.Jenkins;
 import jenkins.security.MasterToSlaveCallable;
 import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.jfrog.build.client.ProxyConfiguration;
 
 import java.io.File;
 import java.io.IOException;
@@ -78,5 +81,23 @@ public class Utils {
 
     public static FilePath createAndGetJfrogCliHomeTempDir(final FilePath ws, String buildNumber) throws IOException, InterruptedException {
         return createAndGetTempDir(ws).child(buildNumber).child(".jfrog");
+    }
+
+    /**
+     * Get the proxy configuration from Jenkins and create a proxy configuration suitable to the ArtifactoryManager.
+     *
+     * @return the proxy configuration
+     */
+    public static ProxyConfiguration createProxyConfiguration() {
+        hudson.ProxyConfiguration proxy = Jenkins.get().getProxy();
+        if (proxy == null) {
+            return null;
+        }
+        ProxyConfiguration proxyConfiguration = new ProxyConfiguration();
+        proxyConfiguration.host = proxy.getName();
+        proxyConfiguration.port = proxy.getPort();
+        proxyConfiguration.username = proxy.getUserName();
+        proxyConfiguration.password = Secret.toString(proxy.getSecretPassword());
+        return proxyConfiguration;
     }
 }

--- a/src/test/java/io/jenkins/plugins/jfrog/CliEnvConfiguratorProxyTest.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/CliEnvConfiguratorProxyTest.java
@@ -1,0 +1,79 @@
+package io.jenkins.plugins.jfrog;
+
+import org.jfrog.build.client.ProxyConfiguration;
+import org.junit.Before;
+import org.junit.Test;
+
+import static io.jenkins.plugins.jfrog.CliEnvConfigurator.*;
+import static org.junit.Assert.assertNull;
+
+
+/**
+ * @author yahavi
+ **/
+@SuppressWarnings("HttpUrlsUsage")
+public class CliEnvConfiguratorProxyTest extends CliEnvConfiguratorTest {
+
+    @Before
+    public void setUp() {
+        super.setUp();
+        proxyConfiguration = new ProxyConfiguration();
+        proxyConfiguration.host = "acme.proxy.io";
+    }
+
+    @Test
+    public void configureCliEnvHttpProxyTest() {
+        proxyConfiguration.port = 80;
+        invokeConfigureCliEnv();
+        assertEnv(envVars, HTTP_PROXY_ENV, "http://acme.proxy.io:80");
+        assertEnv(envVars, HTTPS_PROXY_ENV, "http://acme.proxy.io:80");
+        assertNull(envVars.get(JFROG_CLI_ENV_EXCLUDE));
+    }
+
+    @Test
+    public void configureCliEnvHttpsProxyTest() {
+        proxyConfiguration.port = 443;
+        invokeConfigureCliEnv();
+        assertEnv(envVars, HTTP_PROXY_ENV, "https://acme.proxy.io:443");
+        assertEnv(envVars, HTTPS_PROXY_ENV, "https://acme.proxy.io:443");
+        assertNull(envVars.get(JFROG_CLI_ENV_EXCLUDE));
+    }
+
+    @Test
+    public void configureCliEnvHttpProxyAuthTest() {
+        proxyConfiguration.port = 80;
+        proxyConfiguration.username = "andor";
+        proxyConfiguration.password = "RogueOne";
+        invokeConfigureCliEnv();
+        assertEnv(envVars, HTTP_PROXY_ENV, "http://andor:RogueOne@acme.proxy.io:80");
+        assertEnv(envVars, HTTPS_PROXY_ENV, "http://andor:RogueOne@acme.proxy.io:80");
+        assertEnv(envVars, JFROG_CLI_ENV_EXCLUDE, String.join(";", JFROG_CLI_DEFAULT_EXCLUSIONS, HTTP_PROXY_ENV, HTTPS_PROXY_ENV));
+    }
+
+    @Test
+    public void configureCliEnvHttpsProxyAuthTest() {
+        proxyConfiguration.port = 443;
+        proxyConfiguration.username = "andor";
+        proxyConfiguration.password = "RogueOne";
+        invokeConfigureCliEnv();
+        assertEnv(envVars, HTTP_PROXY_ENV, "https://andor:RogueOne@acme.proxy.io:443");
+        assertEnv(envVars, HTTPS_PROXY_ENV, "https://andor:RogueOne@acme.proxy.io:443");
+        assertEnv(envVars, JFROG_CLI_ENV_EXCLUDE, String.join(";", JFROG_CLI_DEFAULT_EXCLUSIONS, HTTP_PROXY_ENV, HTTPS_PROXY_ENV));
+    }
+
+    @Test
+    public void configureCliEnvNoOverrideHttpTest() {
+        envVars.put(HTTP_PROXY_ENV, "http://acme2.proxy.io:777");
+        invokeConfigureCliEnv();
+        assertEnv(envVars, HTTP_PROXY_ENV, "http://acme2.proxy.io:777");
+    }
+
+    @Test
+    public void configureCliEnvNoOverrideTest() {
+        envVars.put(HTTP_PROXY_ENV, "http://acme2.proxy.io:80");
+        envVars.put(HTTPS_PROXY_ENV, "http://acme2.proxy.io:443");
+        invokeConfigureCliEnv();
+        assertEnv(envVars, HTTP_PROXY_ENV, "http://acme2.proxy.io:80");
+        assertEnv(envVars, HTTPS_PROXY_ENV, "http://acme2.proxy.io:443");
+    }
+}

--- a/src/test/java/io/jenkins/plugins/jfrog/CliEnvConfiguratorTest.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/CliEnvConfiguratorTest.java
@@ -1,0 +1,52 @@
+package io.jenkins.plugins.jfrog;
+
+import hudson.EnvVars;
+import org.jfrog.build.client.ProxyConfiguration;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import static io.jenkins.plugins.jfrog.CliEnvConfigurator.*;
+import static org.junit.Assert.assertEquals;
+
+
+/**
+ * @author yahavi
+ **/
+public class CliEnvConfiguratorTest {
+    ProxyConfiguration proxyConfiguration;
+    EnvVars envVars;
+
+    @Before
+    public void setUp() {
+        envVars = new EnvVars();
+        envVars.put("JOB_NAME", "buildName");
+        envVars.put("BUILD_NUMBER", "1");
+        envVars.put("BUILD_URL", "https://acme.jenkins.io");
+    }
+
+    @Test
+    public void configureCliEnvBasicTest() {
+        invokeConfigureCliEnv("a/b/c");
+        assertEnv(envVars, JFROG_CLI_BUILD_NAME, "buildName");
+        assertEnv(envVars, JFROG_CLI_BUILD_NUMBER, "1");
+        assertEnv(envVars, JFROG_CLI_BUILD_URL, "https://acme.jenkins.io");
+        assertEnv(envVars, JFROG_CLI_HOME_DIR, "a/b/c");
+    }
+
+    void assertEnv(EnvVars envVars, String key, String expectedValue) {
+        assertEquals(expectedValue, envVars.get(key));
+    }
+
+    void invokeConfigureCliEnv() {
+        this.invokeConfigureCliEnv("");
+    }
+
+    void invokeConfigureCliEnv(String jfrogHomeTempDir) {
+        try (MockedStatic<Utils> mockController = Mockito.mockStatic(Utils.class)) {
+            mockController.when(Utils::createProxyConfiguration).thenReturn(proxyConfiguration);
+            configureCliEnv(envVars, jfrogHomeTempDir);
+        }
+    }
+}


### PR DESCRIPTION
- [x] This pull request is created in the [jfrog/jenkins-jfrog-plugin](https://github.com/jfrog/jenkins-jfrog-plugin) repository.

Fix #24 

Add support for HTTP/S proxy.
The proxy support downloading the JFrog CLI and also configuring HTTP_PROXY and HTTPS_PROXY environment variables.

**Usage:**
Set the proxy values in the Plugin Manager:
<img width="1246" alt="image" src="https://user-images.githubusercontent.com/11367982/223984395-19c1edfb-a973-4336-8b5b-b07bb4eea2a8.png">


