### PR TITLE
Improve arguments splitting algorithm

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
         <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs</artifactId>
-            <version>4.5.3</version>
+            <version>4.7.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -195,7 +195,7 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>4.5.3.0</version>
+                <version>4.7.3.2</version>
                 <configuration>
                     <excludeFilterFile>spotbugs-security-exclude.xml</excludeFilterFile>
                     <plugins>

--- a/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
@@ -18,7 +18,6 @@ import io.jenkins.plugins.jfrog.configuration.JFrogPlatformBuilder;
 import io.jenkins.plugins.jfrog.configuration.JFrogPlatformInstance;
 import io.jenkins.plugins.jfrog.plugins.PluginsUtils;
 import jenkins.tasks.SimpleBuildStep;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
@@ -30,6 +29,7 @@ import java.nio.file.Paths;
 import java.util.List;
 
 import static io.jenkins.plugins.jfrog.JfrogInstallation.JFROG_BINARY_PATH;
+import static io.jenkins.plugins.jfrog.Utils.splitByWhitespaces;
 
 /**
  * @author gail
@@ -78,7 +78,7 @@ public class JfStep<T> extends Builder implements SimpleBuildStep {
             jfrogBinaryPath = FilenameUtils.separatorsToUnix(jfrogBinaryPath);
         }
         builder.add(jfrogBinaryPath);
-        builder.add(StringUtils.split(args));
+        builder.add(splitByWhitespaces(args));
         if (isWindows) {
             builder = builder.toWindowsCommand();
         }

--- a/src/main/java/io/jenkins/plugins/jfrog/Utils.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/Utils.java
@@ -4,16 +4,19 @@ import hudson.FilePath;
 import hudson.model.Job;
 import hudson.model.TaskListener;
 import jenkins.security.MasterToSlaveCallable;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.Objects;
+import java.util.regex.Pattern;
 
 /**
  * @author gail
  */
 public class Utils {
+    private static final Pattern SPLIT_BY_WHITESPACE = Pattern.compile("\\s{1,128}(?=([^\"]{0,128}\"[^\"]{0,128}\"){0,128}[^\"]{0,128}$)");
     public static final String BINARY_NAME = "jf";
 
     public static FilePath getWorkspace(Job<?, ?> project) {
@@ -78,5 +81,18 @@ public class Utils {
 
     public static FilePath createAndGetJfrogCliHomeTempDir(final FilePath ws, String buildNumber) throws IOException, InterruptedException {
         return createAndGetTempDir(ws).child(buildNumber).child(".jfrog");
+    }
+
+    /**
+     * Split argument list by whitespaces, ignoring quoted strings.
+     *
+     * @param args - The argument list
+     * @return an array of all arguments
+     */
+    public static String[] splitByWhitespaces(String args) {
+        if (StringUtils.isBlank(args)) {
+            return new String[]{};
+        }
+        return SPLIT_BY_WHITESPACE.split(args);
     }
 }

--- a/src/main/java/io/jenkins/plugins/jfrog/Utils.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/Utils.java
@@ -16,7 +16,7 @@ import java.util.regex.Pattern;
  * @author gail
  */
 public class Utils {
-    private static final Pattern SPLIT_BY_WHITESPACE = Pattern.compile("\\s{1,128}(?=([^\"]{0,128}\"[^\"]{0,128}\"){0,128}[^\"]{0,128}$)");
+    private static final Pattern SPLIT_BY_WHITESPACE = Pattern.compile("\\s{1,128}+(?=([^\"]{0,128}+\"[^\"]{0,128}+\"){0,128}+[^\"]{0,128}+$)");
     public static final String BINARY_NAME = "jf";
 
     public static FilePath getWorkspace(Job<?, ?> project) {

--- a/src/test/java/io/jenkins/plugins/jfrog/UtilsTest.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/UtilsTest.java
@@ -25,6 +25,7 @@ public class UtilsTest {
                 Arguments.of("", new String[]{}),
                 Arguments.of("   \t\n ", new String[]{}),
                 Arguments.of("a", new String[]{"a"}),
+                Arguments.of("a\"", new String[]{"a\""}),
                 Arguments.of("a b", new String[]{"a", "b"}),
                 Arguments.of("a \"b c\"", new String[]{"a", "\"b c\""}),
                 Arguments.of("a & b", new String[]{"a", "&", "b"}),

--- a/src/test/java/io/jenkins/plugins/jfrog/UtilsTest.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/UtilsTest.java
@@ -1,0 +1,41 @@
+package io.jenkins.plugins.jfrog;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static io.jenkins.plugins.jfrog.Utils.splitByWhitespaces;
+
+/**
+ * @author yahavi
+ **/
+public class UtilsTest {
+
+    @ParameterizedTest
+    @MethodSource("splitByWhitespacesProvider")
+    void splitByWhitespacesTest(String input, String[] expectedOutput) {
+        Assertions.assertArrayEquals(expectedOutput, splitByWhitespaces(input));
+    }
+
+    private static Stream<Arguments> splitByWhitespacesProvider() {
+        return Stream.of(
+                Arguments.of("", new String[]{}),
+                Arguments.of("   \t\n ", new String[]{}),
+                Arguments.of("a", new String[]{"a"}),
+                Arguments.of("a b", new String[]{"a", "b"}),
+                Arguments.of("a \"b c\"", new String[]{"a", "\"b c\""}),
+                Arguments.of("a & b", new String[]{"a", "&", "b"}),
+                Arguments.of("a ^ b", new String[]{"a", "^", "b"}),
+                Arguments.of("a$! #b", new String[]{"a$!", "#b"}),
+                Arguments.of("a b c=\"\"", new String[]{"a", "b", "c=\"\""}),
+                Arguments.of("a b c=\"abcd\"", new String[]{"a", "b", "c=\"abcd\""}),
+                Arguments.of("a\n b c=\"ab bc\"", new String[]{"a", "b", "c=\"ab bc\""}),
+                Arguments.of("a b c=\"ab bc\" ", new String[]{"a", "b", "c=\"ab bc\""}),
+                Arguments.of("a b=\"asda \" c=\"ab\r\n bc\" ", new String[]{"a", "b=\"asda \"", "c=\"ab\r\n bc\""}),
+                Arguments.of("\"a ab cde fgh\t \" b=\"asda \" c=\"ab bc\" ", new String[]{"\"a ab cde fgh\t \"", "b=\"asda \"", "c=\"ab bc\""})
+        );
+    }
+}


### PR DESCRIPTION
- [x] This pull request is created in the [jfrog/jenkins-jfrog-plugin](https://github.com/jfrog/jenkins-jfrog-plugin) repository.

Fix #41 

Split arguments by whitespace, except for arguments that contain double quotes.
For example:

```
mvn -Dmaven.test.failure.ignore=true clean install -Ddeploy.testProperty=\"Test Property\"
```
Results
1. mvn
2. -Dmaven.test.failure.ignore=true
3. clean
4. install
5. -Ddeploy.testProperty=\"Test Property\"

