### PR TITLE
Fix after serverId was renamed in PR #36

### DIFF
--- a/src/main/resources/io/jenkins/plugins/jfrog/ArtifactoryInstaller/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/jfrog/ArtifactoryInstaller/config.jelly
@@ -1,7 +1,7 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <f:entry title="${%Server ID}" field="serverId" help="/plugin/jfrog/help/ArtifactoryInstaller/help-serverId.html">
-        <select name="id">
+        <select name="serverId">
             <j:forEach var="server" items="${descriptor.serverIds}">
                 <f:option value="${server.serverId}" selected="${server.serverId==instance.serverId}">${server.serverId}</f:option>
             </j:forEach>


### PR DESCRIPTION
A recent change (PR #36, commit 41161458b313f45c2f5b3eab0df16c1456646830) renamed `id` into `serverId` in the `ArtifactoryInstaller` .

The `<select name="id">` entry in the `jelly` file wasn't renamed accordingly, preventing this field from being saved when the configuration is saved.

This results in this exception when trying to use the Artifactory installer:

```
java.io.IOException: Server id 'null' doesn't exists.
	at io.jenkins.plugins.jfrog.ArtifactoryInstaller.performInstallation(ArtifactoryInstaller.java:64)
	at hudson.tools.InstallerTranslator.getToolHome(InstallerTranslator.java:70)
	at hudson.tools.ToolLocationNodeProperty.getToolHome(ToolLocationNodeProperty.java:109)
	at hudson.tools.ToolInstallation.translateFor(ToolInstallation.java:221)
	at io.jenkins.plugins.jfrog.JfrogInstallation.forNode(JfrogInstallation.java:50)
	at io.jenkins.plugins.jfrog.JfrogInstallation.forNode(JfrogInstallation.java:32)
```

Configuration before this patch:

```xml
    <io.jenkins.plugins.jfrog.JfrogInstallation>
      <name></name>
      <home></home>
      <properties>
        <hudson.tools.InstallSourceProperty>
          <installers>
            <io.jenkins.plugins.jfrog.ArtifactoryInstaller>
              <repository>jfrog-cli-remote</repository>
              <version></version>
            </io.jenkins.plugins.jfrog.ArtifactoryInstaller>
          </installers>
        </hudson.tools.InstallSourceProperty>
      </properties>
    </io.jenkins.plugins.jfrog.JfrogInstallation>
```

Configuration after this patch:

```xml
    <io.jenkins.plugins.jfrog.JfrogInstallation>
      <name></name>
      <home></home>
      <properties>
        <hudson.tools.InstallSourceProperty>
          <installers>
            <io.jenkins.plugins.jfrog.ArtifactoryInstaller>
              <serverId>repo</serverId>
              <repository>jfrog-cli-remote</repository>
              <version></version>
            </io.jenkins.plugins.jfrog.ArtifactoryInstaller>
          </installers>
        </hudson.tools.InstallSourceProperty>
      </properties>
    </io.jenkins.plugins.jfrog.JfrogInstallation>
```