### PR TITLE
Automatically encrypt the JFrog CLI config

### DIFF
--- a/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
@@ -13,6 +13,7 @@ import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
 import hudson.util.ArgumentListBuilder;
 import io.jenkins.cli.shaded.org.apache.commons.io.FilenameUtils;
+import io.jenkins.plugins.jfrog.actions.JFrogCliConfigEncryption;
 import io.jenkins.plugins.jfrog.configuration.Credentials;
 import io.jenkins.plugins.jfrog.configuration.JFrogPlatformBuilder;
 import io.jenkins.plugins.jfrog.configuration.JFrogPlatformInstance;
@@ -142,8 +143,14 @@ public class JfStep<T> extends Builder implements SimpleBuildStep {
      * @throws IOException          in case of any I/O error, or we failed to run the 'jf' command
      */
     public Launcher.ProcStarter setupJFrogEnvironment(Run<?, ?> run, EnvVars env, Launcher launcher, TaskListener listener, FilePath workspace, String jfrogBinaryPath, boolean isWindows) throws IOException, InterruptedException {
+        JFrogCliConfigEncryption jfrogCliConfigEncryption = run.getAction(JFrogCliConfigEncryption.class);
+        if (jfrogCliConfigEncryption == null) {
+            // Set up the config encryption action to allow encrypting the JFrog CLI and make sure we only create one key
+            jfrogCliConfigEncryption = new JFrogCliConfigEncryption(env);
+            run.addAction(jfrogCliConfigEncryption);
+        }
         FilePath jfrogHomeTempDir = Utils.createAndGetJfrogCliHomeTempDir(workspace, String.valueOf(run.getNumber()));
-        CliEnvConfigurator.configureCliEnv(env, jfrogHomeTempDir.getRemote());
+        CliEnvConfigurator.configureCliEnv(env, jfrogHomeTempDir.getRemote(), jfrogCliConfigEncryption);
         Launcher.ProcStarter jfLauncher = launcher.launch().envs(env).pwd(workspace).stdout(listener);
         // Configure all servers, skip if all server ids have already been configured.
         if (shouldConfig(jfrogHomeTempDir)) {

--- a/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
@@ -145,7 +145,7 @@ public class JfStep<T> extends Builder implements SimpleBuildStep {
     public Launcher.ProcStarter setupJFrogEnvironment(Run<?, ?> run, EnvVars env, Launcher launcher, TaskListener listener, FilePath workspace, String jfrogBinaryPath, boolean isWindows) throws IOException, InterruptedException {
         JFrogCliConfigEncryption jfrogCliConfigEncryption = run.getAction(JFrogCliConfigEncryption.class);
         if (jfrogCliConfigEncryption == null) {
-            // Set up the config encryption action to allow encrypting the JFrog CLI and make sure we only create one key
+            // Set up the config encryption action to allow encrypting the JFrog CLI configuration and make sure we only create one key
             jfrogCliConfigEncryption = new JFrogCliConfigEncryption(env);
             run.addAction(jfrogCliConfigEncryption);
         }

--- a/src/main/java/io/jenkins/plugins/jfrog/actions/JFrogCliConfigEncryption.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/actions/JFrogCliConfigEncryption.java
@@ -1,0 +1,52 @@
+package io.jenkins.plugins.jfrog.actions;
+
+import hudson.EnvVars;
+import hudson.model.Action;
+
+import java.util.UUID;
+
+import static io.jenkins.plugins.jfrog.CliEnvConfigurator.JFROG_CLI_HOME_DIR;
+
+/**
+ * This action is injected to the JfStep in order to generate a random key that encrypts the JFrog CLI config.
+ *
+ * @author yahavi
+ **/
+public class JFrogCliConfigEncryption implements Action {
+    private boolean shouldEncrypt;
+    private String key;
+
+    public JFrogCliConfigEncryption(EnvVars env) {
+        if (env.containsKey(JFROG_CLI_HOME_DIR)) {
+            // If JFROG_CLI_HOME_DIR exists, we assume that the user uses a permanent JFrog CLI configuration.
+            // This type of configuration can not be encrypted because 2 different tasks may encrypt with 2 different keys.
+            return;
+        }
+        this.shouldEncrypt = true;
+        // UUID is cryptographically strong encryption key. Without the dashes, it contains exactly 32 characters.
+        this.key = UUID.randomUUID().toString().replaceAll("-", "");
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public boolean shouldEncrypt() {
+        return shouldEncrypt;
+    }
+
+    @Override
+    public String getIconFileName() {
+        return null;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "JFrog CLI config encryption";
+    }
+
+    @Override
+    public String getUrlName() {
+        return null;
+    }
+}

--- a/src/main/java/io/jenkins/plugins/jfrog/actions/JFrogCliConfigEncryption.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/actions/JFrogCliConfigEncryption.java
@@ -23,7 +23,7 @@ public class JFrogCliConfigEncryption implements Action {
             return;
         }
         this.shouldEncrypt = true;
-        // UUID is cryptographically strong encryption key. Without the dashes, it contains exactly 32 characters.
+        // UUID is a cryptographically strong encryption key. Without the dashes, it contains exactly 32 characters.
         this.key = UUID.randomUUID().toString().replaceAll("-", "");
     }
 

--- a/src/test/java/io/jenkins/plugins/jfrog/CliEnvConfiguratorTest.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/CliEnvConfiguratorTest.java
@@ -1,6 +1,7 @@
 package io.jenkins.plugins.jfrog;
 
 import hudson.EnvVars;
+import io.jenkins.plugins.jfrog.actions.JFrogCliConfigEncryption;
 import org.jfrog.build.client.ProxyConfiguration;
 import org.junit.Before;
 import org.junit.Test;
@@ -8,7 +9,7 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import static io.jenkins.plugins.jfrog.CliEnvConfigurator.*;
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 
 /**
@@ -28,11 +29,32 @@ public class CliEnvConfiguratorTest {
 
     @Test
     public void configureCliEnvBasicTest() {
-        invokeConfigureCliEnv("a/b/c");
+        invokeConfigureCliEnv("a/b/c", new JFrogCliConfigEncryption(envVars));
         assertEnv(envVars, JFROG_CLI_BUILD_NAME, "buildName");
         assertEnv(envVars, JFROG_CLI_BUILD_NUMBER, "1");
         assertEnv(envVars, JFROG_CLI_BUILD_URL, "https://acme.jenkins.io");
         assertEnv(envVars, JFROG_CLI_HOME_DIR, "a/b/c");
+    }
+
+    @Test
+    public void configEncryptionTest() {
+        JFrogCliConfigEncryption configEncryption = new JFrogCliConfigEncryption(envVars);
+        assertTrue(configEncryption.shouldEncrypt());
+        assertEquals(32, configEncryption.getKey().length());
+
+        invokeConfigureCliEnv("a/b/c", configEncryption);
+        assertEnv(envVars, JFROG_CLI_ENCRYPTION_KEY, configEncryption.getKey());
+    }
+
+    @Test
+    public void configEncryptionWithHomeDirTest() {
+        // Config JFROG_CLI_HOME_DIR to disable key encryption
+        envVars.put(JFROG_CLI_HOME_DIR, "/a/b/c");
+        JFrogCliConfigEncryption configEncryption = new JFrogCliConfigEncryption(envVars);
+        invokeConfigureCliEnv("", configEncryption);
+
+        assertFalse(configEncryption.shouldEncrypt());
+        assertFalse(envVars.containsKey(JFROG_CLI_ENCRYPTION_KEY));
     }
 
     void assertEnv(EnvVars envVars, String key, String expectedValue) {
@@ -40,13 +62,13 @@ public class CliEnvConfiguratorTest {
     }
 
     void invokeConfigureCliEnv() {
-        this.invokeConfigureCliEnv("");
+        this.invokeConfigureCliEnv("", new JFrogCliConfigEncryption(envVars));
     }
 
-    void invokeConfigureCliEnv(String jfrogHomeTempDir) {
+    void invokeConfigureCliEnv(String jfrogHomeTempDir, JFrogCliConfigEncryption configEncryption) {
         try (MockedStatic<Utils> mockController = Mockito.mockStatic(Utils.class)) {
             mockController.when(Utils::createProxyConfiguration).thenReturn(proxyConfiguration);
-            configureCliEnv(envVars, jfrogHomeTempDir);
+            configureCliEnv(envVars, jfrogHomeTempDir, configEncryption);
         }
     }
 }


### PR DESCRIPTION
- [x] This pull request is created in the [jfrog/jenkins-jfrog-plugin](https://github.com/jfrog/jenkins-jfrog-plugin) repository.

Depends on https://github.com/jfrog/jfrog-cli/pull/1875

Automatically encrypt the JFrog CLI config file with a random key.
The encryption is disabled if the JFROG_CLI_HOME_DIR is set by the user, because in that case, the JFrog CLI home dir may not be unique to the task. If it is not unique, 2 parallel tasks may try to encrypt the same configuration with 2 different keys.