### PR TITLE
Services URLs are not getting updated

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,12 @@
             <artifactId>git</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.26</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jenkins-ci.main</groupId>
             <artifactId>jenkins-test-harness</artifactId>
             <scope>test</scope>

--- a/src/main/java/io/jenkins/plugins/jfrog/BinaryInstaller.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/BinaryInstaller.java
@@ -92,7 +92,7 @@ public abstract class BinaryInstaller extends ToolInstaller {
         JenkinsBuildInfoLog buildInfoLog = new JenkinsBuildInfoLog(log);
 
         // Downloading binary from Artifactory
-        try (ArtifactoryManager manager = new ArtifactoryManager(instance.getArtifactoryUrl(), Secret.toString(instance.getCredentialsConfig().getUsername()),
+        try (ArtifactoryManager manager = new ArtifactoryManager(instance.inferArtifactoryUrl(), Secret.toString(instance.getCredentialsConfig().getUsername()),
                 Secret.toString(instance.getCredentialsConfig().getPassword()), Secret.toString(instance.getCredentialsConfig().getAccessToken()), buildInfoLog)) {
             if (proxyConfiguration != null) {
                 manager.setProxyConfiguration(proxyConfiguration);
@@ -101,9 +101,9 @@ public abstract class BinaryInstaller extends ToolInstaller {
             String artifactorySha256 = getArtifactSha256(manager, cliUrlSuffix);
             if (shouldDownloadTool(toolLocation, artifactorySha256)) {
                 if (version.equals(RELEASE)) {
-                    log.getLogger().printf("Download '%s' latest version from: %s%n", binaryName, instance.getArtifactoryUrl() + cliUrlSuffix);
+                    log.getLogger().printf("Download '%s' latest version from: %s%n", binaryName, instance.inferArtifactoryUrl() + cliUrlSuffix);
                 } else {
-                    log.getLogger().printf("Download '%s' version %s from: %s%n", binaryName, version, instance.getArtifactoryUrl() + cliUrlSuffix);
+                    log.getLogger().printf("Download '%s' version %s from: %s%n", binaryName, version, instance.inferArtifactoryUrl() + cliUrlSuffix);
                 }
                 File downloadResponse = manager.downloadToFile(cliUrlSuffix, new File(toolLocation, binaryName).getPath());
                 if (!downloadResponse.setExecutable(true)) {

--- a/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
@@ -206,9 +206,9 @@ public class JfStep<T> extends Builder implements SimpleBuildStep {
         }
         // Add URLs
         builder.add("--url=" + jfrogPlatformInstance.getUrl());
-        builder.add("--artifactory-url=" + jfrogPlatformInstance.getArtifactoryUrl());
-        builder.add("--distribution-url=" + jfrogPlatformInstance.getDistributionUrl());
-        builder.add("--xray-url=" + jfrogPlatformInstance.getXrayUrl());
+        builder.add("--artifactory-url=" + jfrogPlatformInstance.inferArtifactoryUrl());
+        builder.add("--distribution-url=" + jfrogPlatformInstance.inferDistributionUrl());
+        builder.add("--xray-url=" + jfrogPlatformInstance.inferXrayUrl());
 
         builder.add("--interactive=false");
         // The installation process takes place more than once per build, so we will configure the same server ID several times.

--- a/src/main/java/io/jenkins/plugins/jfrog/configuration/JFrogPlatformInstance.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/configuration/JFrogPlatformInstance.java
@@ -59,7 +59,7 @@ public class JFrogPlatformInstance implements Serializable {
     }
 
     /**
-     * Get artifactory URL if configured. Otherwise, infer the Artifactory URL from the platform URL.
+     * Get Artifactory URL if configured. Otherwise, infer the Artifactory URL from the platform URL.
      *
      * @return Artifactory URL.
      */

--- a/src/main/java/io/jenkins/plugins/jfrog/configuration/JFrogPlatformInstance.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/configuration/JFrogPlatformInstance.java
@@ -1,5 +1,7 @@
 package io.jenkins.plugins.jfrog.configuration;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -9,7 +11,13 @@ import java.util.List;
 /**
  * Represents an instance of jenkins JFrog instance configuration page.
  */
+@Getter
+@Setter
 public class JFrogPlatformInstance implements Serializable {
+    private static final String DISTRIBUTION_SUFFIX = "/distribution";
+    private static final String ARTIFACTORY_SUFFIX = "/artifactory";
+    private static final String XRAY_SUFFIX = "/xray";
+
     private String url;
     private String artifactoryUrl;
     private String distributionUrl;
@@ -20,15 +28,11 @@ public class JFrogPlatformInstance implements Serializable {
     @DataBoundConstructor
     public JFrogPlatformInstance(String serverId, String url, CredentialsConfig credentialsConfig, String artifactoryUrl, String distributionUrl, String xrayUrl) {
         this.id = serverId;
-        this.url = StringUtils.isNotEmpty(url) ? StringUtils.removeEnd(url, "/") : null;
         this.credentialsConfig = credentialsConfig;
-        this.artifactoryUrl = addUrlSuffix(artifactoryUrl, this.url, "artifactory");
-        this.distributionUrl = addUrlSuffix(distributionUrl, this.url, "distribution");
-        this.xrayUrl = addUrlSuffix(xrayUrl, this.url, "xray");
-    }
-
-    public CredentialsConfig getCredentialsConfig() {
-        return credentialsConfig;
+        this.url = StringUtils.removeEnd(url, "/");
+        this.artifactoryUrl = StringUtils.removeEnd(artifactoryUrl, "/");
+        this.distributionUrl = StringUtils.removeEnd(distributionUrl, "/");
+        this.xrayUrl = StringUtils.removeEnd(xrayUrl, "/");
     }
 
     /**
@@ -40,28 +44,6 @@ public class JFrogPlatformInstance implements Serializable {
     @SuppressWarnings("unused")
     public List<JFrogPlatformInstance> getJfrogInstances() {
         return JFrogPlatformBuilder.getJFrogPlatformInstances();
-    }
-
-    private String addUrlSuffix(String Url, String platformUrl, String suffix) {
-        return StringUtils.isNotEmpty(Url) ? Url : platformUrl + "/" + suffix;
-    }
-
-    // Required by external plugins (JCasC).
-    @SuppressWarnings("unused")
-    public String getId() {
-        return id;
-    }
-
-    // Required by external plugins (JCasC).
-    @SuppressWarnings("unused")
-    public String getUrl() {
-        return url;
-    }
-
-    // Required by external plugins (JCasC).
-    @SuppressWarnings("unused")
-    public void setUrl(String url) {
-        this.url = url;
     }
 
     // Required by external plugins (JCasC).
@@ -76,51 +58,30 @@ public class JFrogPlatformInstance implements Serializable {
         this.id = serverId;
     }
 
-    // Required by external plugins (JCasC).
-    @SuppressWarnings("unused")
-    public String getArtifactoryUrl() {
-        return artifactoryUrl;
+    /**
+     * Get artifactory URL if configured. Otherwise, infer the Artifactory URL from the platform URL.
+     *
+     * @return Artifactory URL.
+     */
+    public String inferArtifactoryUrl() {
+        return StringUtils.defaultIfBlank(artifactoryUrl, url + ARTIFACTORY_SUFFIX);
     }
 
-    // Required by external plugins (JCasC).
-    @SuppressWarnings("unused")
-    public void setArtifactoryUrl(String artifactoryUrl) {
-        this.artifactoryUrl = artifactoryUrl;
+    /**
+     * Get Distribution URL if configured. Otherwise, infer the Distribution URL from the platform URL.
+     *
+     * @return Distribution URL.
+     */
+    public String inferDistributionUrl() {
+        return StringUtils.defaultIfBlank(distributionUrl, this.url + DISTRIBUTION_SUFFIX);
     }
 
-    // Required by external plugins (JCasC).
-    @SuppressWarnings("unused")
-    public String getDistributionUrl() {
-        return distributionUrl;
-    }
-
-    // Required by external plugins (JCasC).
-    @SuppressWarnings("unused")
-    public void setDistributionUrl(String distributionUrl) {
-        this.distributionUrl = distributionUrl;
-    }
-
-    // Required by external plugins (JCasC).
-    @SuppressWarnings("unused")
-    public String getXrayUrl() {
-        return xrayUrl;
-    }
-
-    // Required by external plugins (JCasC).
-    @SuppressWarnings("unused")
-    public void setXrayUrl(String xrayUrl) {
-        this.xrayUrl = xrayUrl;
-    }
-
-    // Required by external plugins (JCasC).
-    @SuppressWarnings("unused")
-    public void setId(String id) {
-        this.id = id;
-    }
-
-    // Required by external plugins (JCasC).
-    @SuppressWarnings("unused")
-    public void setCredentialsConfig(CredentialsConfig credentialsConfig) {
-        this.credentialsConfig = credentialsConfig;
+    /**
+     * Get Xray URL if configured. Otherwise, infer the Xray URL from the platform URL.
+     *
+     * @return Distribution URL.
+     */
+    public String inferXrayUrl() {
+        return StringUtils.defaultIfBlank(xrayUrl, this.url + XRAY_SUFFIX);
     }
 }

--- a/src/test/java/io/jenkins/plugins/jfrog/configuration/JFrogPlatformInstanceTest.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/configuration/JFrogPlatformInstanceTest.java
@@ -1,0 +1,56 @@
+package io.jenkins.plugins.jfrog.configuration;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author yahavi
+ **/
+public class JFrogPlatformInstanceTest {
+
+    private static final String DISTRIBUTION_URL = "https://acme.jfrog.io/distribution";
+    private static final String ARTIFACTORY_URL = "https://acme.jfrog.io/artifactory";
+    private static final String XRAY_URL = "https://acme.jfrog.io/xray";
+    private static final String URL = "https://acme.jfrog.io";
+    private static final String SERVER_ID = "acme";
+
+    @Test
+    public void testInferArtifactoryUrl() {
+        // Check that Artifactory URL inferred from the platform URL
+        JFrogPlatformInstance jfrogPlatformInstance = new JFrogPlatformInstance(SERVER_ID, URL, null, "", "", "");
+        assertEquals("", jfrogPlatformInstance.getArtifactoryUrl());
+        assertEquals(ARTIFACTORY_URL, jfrogPlatformInstance.inferArtifactoryUrl());
+
+        // Check that Artifactory URL does not inferred from the platform URL
+        jfrogPlatformInstance = new JFrogPlatformInstance(SERVER_ID, "", null, ARTIFACTORY_URL, "", "");
+        assertEquals(ARTIFACTORY_URL, jfrogPlatformInstance.getArtifactoryUrl());
+        assertEquals(ARTIFACTORY_URL, jfrogPlatformInstance.inferArtifactoryUrl());
+    }
+
+    @Test
+    public void testInferDistributionUrl() {
+        // Check that Distribution URL inferred from the platform URL
+        JFrogPlatformInstance jfrogPlatformInstance = new JFrogPlatformInstance(SERVER_ID, URL, null, "", "", "");
+        assertEquals("", jfrogPlatformInstance.getDistributionUrl());
+        assertEquals(DISTRIBUTION_URL, jfrogPlatformInstance.inferDistributionUrl());
+
+        // Check that Distribution URL does not inferred from the platform URL
+        jfrogPlatformInstance = new JFrogPlatformInstance(SERVER_ID, "", null, "", DISTRIBUTION_URL, "");
+        assertEquals(DISTRIBUTION_URL, jfrogPlatformInstance.getDistributionUrl());
+        assertEquals(DISTRIBUTION_URL, jfrogPlatformInstance.inferDistributionUrl());
+    }
+
+    @Test
+    public void testInferXrayUrl() {
+        // Check that Xray URL inferred from the platform URL
+        JFrogPlatformInstance jfrogPlatformInstance = new JFrogPlatformInstance(SERVER_ID, URL, null, "", "", "");
+        assertEquals("", jfrogPlatformInstance.getXrayUrl());
+        assertEquals(XRAY_URL, jfrogPlatformInstance.inferXrayUrl());
+
+        // Check that Xray URL does not inferred from the platform URL
+        jfrogPlatformInstance = new JFrogPlatformInstance(SERVER_ID, "", null, "", "", XRAY_URL);
+        assertEquals(XRAY_URL, jfrogPlatformInstance.getXrayUrl());
+        assertEquals(XRAY_URL, jfrogPlatformInstance.inferXrayUrl());
+    }
+}

--- a/src/test/java/io/jenkins/plugins/jfrog/configuration/JFrogPlatformInstanceTest.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/configuration/JFrogPlatformInstanceTest.java
@@ -22,7 +22,7 @@ public class JFrogPlatformInstanceTest {
         assertEquals("", jfrogPlatformInstance.getArtifactoryUrl());
         assertEquals(ARTIFACTORY_URL, jfrogPlatformInstance.inferArtifactoryUrl());
 
-        // Check that Artifactory URL does not inferred from the platform URL
+        // Check that Artifactory URL is not inferred from the platform URL
         jfrogPlatformInstance = new JFrogPlatformInstance(SERVER_ID, "", null, ARTIFACTORY_URL, "", "");
         assertEquals(ARTIFACTORY_URL, jfrogPlatformInstance.getArtifactoryUrl());
         assertEquals(ARTIFACTORY_URL, jfrogPlatformInstance.inferArtifactoryUrl());
@@ -35,7 +35,7 @@ public class JFrogPlatformInstanceTest {
         assertEquals("", jfrogPlatformInstance.getDistributionUrl());
         assertEquals(DISTRIBUTION_URL, jfrogPlatformInstance.inferDistributionUrl());
 
-        // Check that Distribution URL does not inferred from the platform URL
+        // Check that Distribution URL is not inferred from the platform URL
         jfrogPlatformInstance = new JFrogPlatformInstance(SERVER_ID, "", null, "", DISTRIBUTION_URL, "");
         assertEquals(DISTRIBUTION_URL, jfrogPlatformInstance.getDistributionUrl());
         assertEquals(DISTRIBUTION_URL, jfrogPlatformInstance.inferDistributionUrl());
@@ -48,7 +48,7 @@ public class JFrogPlatformInstanceTest {
         assertEquals("", jfrogPlatformInstance.getXrayUrl());
         assertEquals(XRAY_URL, jfrogPlatformInstance.inferXrayUrl());
 
-        // Check that Xray URL does not inferred from the platform URL
+        // Check that Xray URL is not inferred from the platform URL
         jfrogPlatformInstance = new JFrogPlatformInstance(SERVER_ID, "", null, "", "", XRAY_URL);
         assertEquals(XRAY_URL, jfrogPlatformInstance.getXrayUrl());
         assertEquals(XRAY_URL, jfrogPlatformInstance.inferXrayUrl());


### PR DESCRIPTION
- [x] This pull request is created in the [jfrog/jenkins-jfrog-plugin](https://github.com/jfrog/jenkins-jfrog-plugin) repository.

**The issue**
1. Configure and save a JFrog server and click save.
2. Edit the platform URL - the services URLs are not updated.

**The solution**
Don't save the services URLs unless specified.
Instead, save only the JFrog platform URL and infer the services URLs during runtime.