### PR TITLE
On MacOSX, os.arch=aarch64 should use arm64 variant of jf

### DIFF
--- a/src/main/java/io/jenkins/plugins/jfrog/OsUtils.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/OsUtils.java
@@ -17,7 +17,7 @@ public class OsUtils {
         }
         // Mac
         if (SystemUtils.IS_OS_MAC) {
-            if (OS_ARCH.contains("arm64")) {
+            if (OS_ARCH.contains("arm64") || OS_ARCH.contains("aarch64")) {
                 return "mac-arm64";
             }
             return "mac-386";


### PR DESCRIPTION
My macmini (arm64) isn't capable of running the i386 variant of the binary, but is capable of running the mac-arm64 variant. This seems to be a problem with the Amazon Corretto Java 11 JDK installed.

Closes issue #17

- [x] This pull request is created in the [jfrog/jenkins-jfrog-plugin](https://github.com/jfrog/jenkins-jfrog-plugin) repository.
