### PR TITLE
Support No-Proxy hosts with dash

### DIFF
--- a/src/main/java/io/jenkins/plugins/jfrog/configuration/JenkinsProxyConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/configuration/JenkinsProxyConfiguration.java
@@ -15,7 +15,7 @@ import java.util.regex.Pattern;
  * Because of the Jenkins.get() used in the constructor, you can only create it on the master, not on an agent.
  */
 public class JenkinsProxyConfiguration extends ProxyConfiguration {
-    private static final Pattern HOST_NAME_PATTERN = Pattern.compile("^.*?://?([\\w.]+).*");
+    private static final Pattern HOST_NAME_PATTERN = Pattern.compile("^.*?://?([\\w.-]+).*");
     public List<Pattern> noProxyHostPatterns;
     public String noProxy;
 

--- a/src/test/java/io/jenkins/plugins/jfrog/configuration/JenkinsProxyConfigurationTest.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/configuration/JenkinsProxyConfigurationTest.java
@@ -1,6 +1,7 @@
 package io.jenkins.plugins.jfrog.configuration;
 
 import jenkins.model.Jenkins;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -63,6 +64,10 @@ public class JenkinsProxyConfigurationTest {
 
         setupProxy("acme.jfrog.info");
         assertFalse(new JenkinsProxyConfiguration().shouldBypassProxy(url));
+
+        setupProxy("acme.jfrog.io-dashed");
+        String dashedUrl = StringUtils.replace(url, "acme.jfrog.io", "acme.jfrog.io-dashed");
+        assertTrue(new JenkinsProxyConfiguration().shouldBypassProxy(dashedUrl));
     }
 
     private void setupProxy(String noProxyHost) {


### PR DESCRIPTION
- [x] This pull request is created in the [jfrog/jenkins-jfrog-plugin](https://github.com/jfrog/jenkins-jfrog-plugin) repository.

Fix #93 

Providing a no-proxy host with a dash character does not match any URL because the regex pattern `[\\w.]+` only accepts letters, numbers, and underscores.