### PR TITLE
Incorrect JCasC configuration for latest JFrog CLI

### DIFF
--- a/src/main/java/io/jenkins/plugins/jfrog/ArtifactoryInstaller.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/ArtifactoryInstaller.java
@@ -10,6 +10,8 @@ import io.jenkins.plugins.jfrog.configuration.CredentialsConfig;
 import io.jenkins.plugins.jfrog.configuration.JFrogPlatformBuilder;
 import io.jenkins.plugins.jfrog.configuration.JFrogPlatformInstance;
 import io.jenkins.plugins.jfrog.plugins.PluginsUtils;
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
 import org.jfrog.build.client.Version;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -26,6 +28,7 @@ import java.util.regex.Pattern;
  *
  * @author gail
  */
+@Getter
 @SuppressWarnings("unused")
 public class ArtifactoryInstaller extends BinaryInstaller {
     private static final Version MIN_CLI_VERSION = new Version("2.6.1");
@@ -35,7 +38,8 @@ public class ArtifactoryInstaller extends BinaryInstaller {
 
     final String serverId;
     final String repository;
-    final String version;
+    @Setter
+    String version;
 
     @DataBoundConstructor
     public ArtifactoryInstaller(String serverId, String repository, String version) {
@@ -43,18 +47,6 @@ public class ArtifactoryInstaller extends BinaryInstaller {
         this.serverId = serverId;
         this.repository = StringUtils.trim(repository);
         this.version = StringUtils.trim(version);
-    }
-
-    public String getServerId() {
-        return serverId;
-    }
-
-    public String getRepository() {
-        return repository;
-    }
-
-    public String getVersion() {
-        return version;
     }
 
     @Override
@@ -72,7 +64,7 @@ public class ArtifactoryInstaller extends BinaryInstaller {
      */
     JFrogPlatformInstance getSpecificServer(String id) {
         List<JFrogPlatformInstance> jfrogInstances = JFrogPlatformBuilder.getJFrogPlatformInstances();
-        if (jfrogInstances != null && jfrogInstances.size() > 0) {
+        if (jfrogInstances != null && !jfrogInstances.isEmpty()) {
             for (JFrogPlatformInstance jfrogPlatformInstance : jfrogInstances) {
                 if (jfrogPlatformInstance.getId().equals(id)) {
                     // Getting credentials

--- a/src/main/java/io/jenkins/plugins/jfrog/JfrogInstallation.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfrogInstallation.java
@@ -110,7 +110,7 @@ public class JfrogInstallation extends ToolInstallation
         public List<? extends ToolInstaller> getDefaultInstallers() {
             List<ToolInstaller> installersList = new ArrayList<>();
             // The default installation will be from 'releases.jfrog.io'
-            installersList.add(new ReleasesInstaller(null));
+            installersList.add(new ReleasesInstaller());
             return installersList;
         }
 

--- a/src/main/java/io/jenkins/plugins/jfrog/ReleasesInstaller.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/ReleasesInstaller.java
@@ -8,6 +8,7 @@ import io.jenkins.plugins.jfrog.configuration.CredentialsConfig;
 import io.jenkins.plugins.jfrog.configuration.JFrogPlatformInstance;
 import org.apache.commons.lang3.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.verb.POST;
 
@@ -23,8 +24,13 @@ public class ReleasesInstaller extends ArtifactoryInstaller {
     private static final String RELEASES_REPOSITORY = "jfrog-cli";
 
     @DataBoundConstructor
-    public ReleasesInstaller(String version) {
-        super("", RELEASES_REPOSITORY, version);
+    public ReleasesInstaller() {
+        super("", RELEASES_REPOSITORY, "");
+    }
+
+    @DataBoundSetter
+    public void setVersion(String version) {
+        super.setVersion(version);
     }
 
     @Override

--- a/src/test/java/io/jenkins/plugins/jfrog/integration/PipelineTestBase.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/integration/PipelineTestBase.java
@@ -284,7 +284,9 @@ public class PipelineTestBase {
     }
 
     public static void configureJfrogCliFromReleases(String cliVersion, Boolean override) throws Exception {
-        configureJfrogCliTool(JFROG_CLI_TOOL_NAME_1, new ReleasesInstaller(cliVersion), override);
+        ReleasesInstaller releasesInstaller = new ReleasesInstaller();
+        releasesInstaller.setVersion(cliVersion);
+        configureJfrogCliTool(JFROG_CLI_TOOL_NAME_1, releasesInstaller, override);
     }
 
     public static void configureJfrogCliFromArtifactory(String toolName, String serverId, String repo, Boolean override) throws Exception {


### PR DESCRIPTION
- [x] This pull request is created in the [jfrog/jenkins-jfrog-plugin](https://github.com/jfrog/jenkins-jfrog-plugin) repository.

Fix https://github.com/jenkinsci/jfrog-plugin/issues/30

Incorrect JCasC configuration export occurs when the JFrog CLI installation is set to “install the latest version”. The root cause is that the ArtifactoryInstaller constructor only accepts non-empty version values. This pull request changes this behavior by allowing the constructor to accept an empty version, and providing a setter for JCasC to set the version if specified.