### PR TITLE
Set encryption key as Jenkins Secret

### DIFF
--- a/src/main/java/io/jenkins/plugins/jfrog/CliEnvConfigurator.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/CliEnvConfigurator.java
@@ -46,7 +46,7 @@ public class CliEnvConfigurator {
         if (encryptionKey.shouldEncrypt()) {
             // Set up a random encryption key and set as a Jenkins secret
             JenkinsSecretManager js = new JenkinsSecretManager();
-            js.createSecret(JFROG_CLI_ENCRYPTION_KEY, encryptionKey.getKey(),"JFrog CLI encryption key");
+            js.createSecret(JFROG_CLI_ENCRYPTION_KEY, encryptionKey.getKey(), "JFrog CLI encryption key");
         }
     }
 

--- a/src/main/java/io/jenkins/plugins/jfrog/CliEnvConfigurator.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/CliEnvConfigurator.java
@@ -3,6 +3,7 @@ package io.jenkins.plugins.jfrog;
 import hudson.EnvVars;
 import io.jenkins.plugins.jfrog.actions.JFrogCliConfigEncryption;
 import io.jenkins.plugins.jfrog.configuration.JenkinsProxyConfiguration;
+import io.jenkins.plugins.jfrog.configuration.JenkinsSecretManager;
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -43,8 +44,9 @@ public class CliEnvConfigurator {
             setupProxy(env);
         }
         if (encryptionKey.shouldEncrypt()) {
-            // Set up a random encryption key to make sure no raw text secrets are stored in the file system
-            env.putIfAbsent(JFROG_CLI_ENCRYPTION_KEY, encryptionKey.getKey());
+            // Set up a random encryption key and set as a Jenkins secret
+            JenkinsSecretManager js = new JenkinsSecretManager();
+            js.createSecret(JFROG_CLI_ENCRYPTION_KEY, encryptionKey.getKey(),"JFrog CLI encryption key");
         }
     }
 

--- a/src/main/java/io/jenkins/plugins/jfrog/Utils.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/Utils.java
@@ -4,6 +4,7 @@ import hudson.FilePath;
 import hudson.model.Job;
 import hudson.model.TaskListener;
 import io.jenkins.plugins.jfrog.callables.TempDirCreator;
+import io.jenkins.plugins.jfrog.configuration.JenkinsSecretManager;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import java.io.IOException;
@@ -62,5 +63,10 @@ public class Utils {
 
     public static FilePath createAndGetJfrogCliHomeTempDir(final FilePath ws, String buildNumber) throws IOException, InterruptedException {
         return createAndGetTempDir(ws).child(buildNumber).child(".jfrog");
+    }
+
+    public static void deleteEncryptionKeySecret() {
+        JenkinsSecretManager js = new JenkinsSecretManager();
+        js.deleteSecret(CliEnvConfigurator.JFROG_CLI_ENCRYPTION_KEY);
     }
 }

--- a/src/main/java/io/jenkins/plugins/jfrog/WorkflowListener.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/WorkflowListener.java
@@ -29,6 +29,7 @@ public class WorkflowListener extends FlowExecutionListener {
         try {
             WorkflowRun build = getWorkflowRun(execution);
             Utils.deleteBuildJfrogHomeDir(getWorkspace(build.getParent()), String.valueOf(build.getNumber()), getTaskListener(execution));
+            Utils.deleteEncryptionKeySecret();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/io/jenkins/plugins/jfrog/configuration/JenkinsSecretManager.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/configuration/JenkinsSecretManager.java
@@ -16,7 +16,7 @@ public class JenkinsSecretManager {
 
     public void createSecret(String name, String value, String description) {
         StringCredentialsImpl secret = new StringCredentialsImpl(
-                CredentialsScope.GLOBAL,
+                CredentialsScope.USER,
                 name,
                 description,
                 Secret.fromString(value)
@@ -31,14 +31,21 @@ public class JenkinsSecretManager {
 
     public void deleteSecret(String id) {
         List<Credentials> credentials = SystemCredentialsProvider.getInstance().getCredentials();
-        credentials.removeIf(cred -> {
-            cred.getScope();
-            return false;
-        });
-        try {
-            SystemCredentialsProvider.getInstance().save();
-        } catch (IOException e) {
-            e.printStackTrace();
+        Credentials toRemove = null;
+        for (Credentials credential : credentials) {
+            if (credential instanceof StringCredentialsImpl && ((StringCredentialsImpl) credential).getId().equals(id)) {
+                toRemove = credential;
+                break;
+            }
         }
+        if (toRemove != null) {
+            try {
+                SystemCredentialsProvider.getInstance().getCredentials().remove(toRemove);
+                SystemCredentialsProvider.getInstance().save();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+
     }
 }

--- a/src/main/java/io/jenkins/plugins/jfrog/configuration/JenkinsSecretManager.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/configuration/JenkinsSecretManager.java
@@ -3,7 +3,6 @@ package io.jenkins.plugins.jfrog.configuration;
 import com.cloudbees.plugins.credentials.Credentials;
 import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
-import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import hudson.util.Secret;
 import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl;
 
@@ -15,6 +14,10 @@ import java.util.List;
 public class JenkinsSecretManager {
 
     public void createSecret(String name, String value, String description) {
+        if (secretExists(name)) {
+            System.out.println("Secret with name " + name + " already exists.");
+            return;
+        }
         StringCredentialsImpl secret = new StringCredentialsImpl(
                 CredentialsScope.USER,
                 name,
@@ -47,5 +50,15 @@ public class JenkinsSecretManager {
             }
         }
 
+    }
+
+    public boolean secretExists(String name) {
+        List<Credentials> credentials = SystemCredentialsProvider.getInstance().getCredentials();
+        for (Credentials credential : credentials) {
+            if (credential instanceof StringCredentialsImpl && ((StringCredentialsImpl) credential).getId().equals(name)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/main/java/io/jenkins/plugins/jfrog/configuration/JenkinsSecretManager.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/configuration/JenkinsSecretManager.java
@@ -1,0 +1,44 @@
+package io.jenkins.plugins.jfrog.configuration;
+
+import com.cloudbees.plugins.credentials.Credentials;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
+import hudson.util.Secret;
+import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl;
+
+
+import java.io.IOException;
+import java.util.List;
+
+
+public class JenkinsSecretManager {
+
+    public void createSecret(String name, String value, String description) {
+        StringCredentialsImpl secret = new StringCredentialsImpl(
+                CredentialsScope.GLOBAL,
+                name,
+                description,
+                Secret.fromString(value)
+        );
+        try {
+            SystemCredentialsProvider.getInstance().getCredentials().add(secret);
+            SystemCredentialsProvider.getInstance().save();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void deleteSecret(String id) {
+        List<Credentials> credentials = SystemCredentialsProvider.getInstance().getCredentials();
+        credentials.removeIf(cred -> {
+            cred.getScope();
+            return false;
+        });
+        try {
+            SystemCredentialsProvider.getInstance().save();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/jfrog/configuration/JenkinsSecretManager.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/configuration/JenkinsSecretManager.java
@@ -52,6 +52,16 @@ public class JenkinsSecretManager {
 
     }
 
+    public Secret getSecret(String name) {
+        List<Credentials> credentials = SystemCredentialsProvider.getInstance().getCredentials();
+        for (Credentials credential : credentials) {
+            if (credential instanceof StringCredentialsImpl && ((StringCredentialsImpl) credential).getId().equals(name)) {
+                return ((StringCredentialsImpl) credential).getSecret();
+            }
+        }
+        return null;
+    }
+
     public boolean secretExists(String name) {
         List<Credentials> credentials = SystemCredentialsProvider.getInstance().getCredentials();
         for (Credentials credential : credentials) {

--- a/src/test/java/io/jenkins/plugins/jfrog/CliEnvConfiguratorTest.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/CliEnvConfiguratorTest.java
@@ -3,6 +3,7 @@ package io.jenkins.plugins.jfrog;
 import hudson.EnvVars;
 import io.jenkins.plugins.jfrog.actions.JFrogCliConfigEncryption;
 import io.jenkins.plugins.jfrog.configuration.JenkinsProxyConfiguration;
+import io.jenkins.plugins.jfrog.configuration.JenkinsSecretManager;
 import jenkins.model.Jenkins;
 import org.junit.Before;
 import org.junit.Rule;
@@ -39,26 +40,26 @@ public class CliEnvConfiguratorTest {
         assertEnv(envVars, JFROG_CLI_HOME_DIR, "a/b/c");
     }
 
-//    @Test
-//    public void configEncryptionTest() {
-//        JFrogCliConfigEncryption configEncryption = new JFrogCliConfigEncryption(envVars);
-//        assertTrue(configEncryption.shouldEncrypt());
-//        assertEquals(32, configEncryption.getKey().length());
-//
-//        invokeConfigureCliEnv("a/b/c", configEncryption);
-//        assertEnv(envVars, JFROG_CLI_ENCRYPTION_KEY, configEncryption.getKey());
-//    }
+    @Test
+    public void configEncryptionTest() {
+        JFrogCliConfigEncryption configEncryption = new JFrogCliConfigEncryption(envVars);
+        assertTrue(configEncryption.shouldEncrypt());
+        assertEquals(32, configEncryption.getKey().length());
 
-//    @Test
-//    public void configEncryptionWithHomeDirTest() {
-//        // Config JFROG_CLI_HOME_DIR to disable key encryption
-//        envVars.put(JFROG_CLI_HOME_DIR, "/a/b/c");
-//        JFrogCliConfigEncryption configEncryption = new JFrogCliConfigEncryption(envVars);
-//        invokeConfigureCliEnv("", configEncryption);
-//
-//        assertFalse(configEncryption.shouldEncrypt());
-//        assertFalse(envVars.containsKey(JFROG_CLI_ENCRYPTION_KEY));
-//    }
+        invokeConfigureCliEnv("a/b/c", configEncryption);
+        assertEquals(configEncryption.getKey(), new JenkinsSecretManager().getSecret(JFROG_CLI_ENCRYPTION_KEY).getPlainText());
+    }
+
+    @Test
+    public void configEncryptionWithHomeDirTest() {
+        // Config JFROG_CLI_HOME_DIR to disable key encryption
+        envVars.put(JFROG_CLI_HOME_DIR, "/a/b/c");
+        JFrogCliConfigEncryption configEncryption = new JFrogCliConfigEncryption(envVars);
+        invokeConfigureCliEnv("", configEncryption);
+
+        assertFalse(configEncryption.shouldEncrypt());
+        assertNull(new JenkinsSecretManager().getSecret(JFROG_CLI_ENCRYPTION_KEY));
+    }
 
     void assertEnv(EnvVars envVars, String key, String expectedValue) {
         assertEquals(expectedValue, envVars.get(key));

--- a/src/test/java/io/jenkins/plugins/jfrog/CliEnvConfiguratorTest.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/CliEnvConfiguratorTest.java
@@ -39,26 +39,26 @@ public class CliEnvConfiguratorTest {
         assertEnv(envVars, JFROG_CLI_HOME_DIR, "a/b/c");
     }
 
-    @Test
-    public void configEncryptionTest() {
-        JFrogCliConfigEncryption configEncryption = new JFrogCliConfigEncryption(envVars);
-        assertTrue(configEncryption.shouldEncrypt());
-        assertEquals(32, configEncryption.getKey().length());
+//    @Test
+//    public void configEncryptionTest() {
+//        JFrogCliConfigEncryption configEncryption = new JFrogCliConfigEncryption(envVars);
+//        assertTrue(configEncryption.shouldEncrypt());
+//        assertEquals(32, configEncryption.getKey().length());
+//
+//        invokeConfigureCliEnv("a/b/c", configEncryption);
+//        assertEnv(envVars, JFROG_CLI_ENCRYPTION_KEY, configEncryption.getKey());
+//    }
 
-        invokeConfigureCliEnv("a/b/c", configEncryption);
-        assertEnv(envVars, JFROG_CLI_ENCRYPTION_KEY, configEncryption.getKey());
-    }
-
-    @Test
-    public void configEncryptionWithHomeDirTest() {
-        // Config JFROG_CLI_HOME_DIR to disable key encryption
-        envVars.put(JFROG_CLI_HOME_DIR, "/a/b/c");
-        JFrogCliConfigEncryption configEncryption = new JFrogCliConfigEncryption(envVars);
-        invokeConfigureCliEnv("", configEncryption);
-
-        assertFalse(configEncryption.shouldEncrypt());
-        assertFalse(envVars.containsKey(JFROG_CLI_ENCRYPTION_KEY));
-    }
+//    @Test
+//    public void configEncryptionWithHomeDirTest() {
+//        // Config JFROG_CLI_HOME_DIR to disable key encryption
+//        envVars.put(JFROG_CLI_HOME_DIR, "/a/b/c");
+//        JFrogCliConfigEncryption configEncryption = new JFrogCliConfigEncryption(envVars);
+//        invokeConfigureCliEnv("", configEncryption);
+//
+//        assertFalse(configEncryption.shouldEncrypt());
+//        assertFalse(envVars.containsKey(JFROG_CLI_ENCRYPTION_KEY));
+//    }
 
     void assertEnv(EnvVars envVars, String key, String expectedValue) {
         assertEquals(expectedValue, envVars.get(key));


### PR DESCRIPTION
- [x] This pull request is created in the [jfrog/jenkins-jfrog-plugin](https://github.com/jfrog/jenkins-jfrog-plugin) repository.

Set the JFrog CLI encryption key as a temp Jenkins secret that will be deleted after the job finishes.

TODO:
Add tests.