### PR TITLE
Remove the log message that indicates the deletion of .jfrog directory

### DIFF
--- a/src/main/java/io/jenkins/plugins/jfrog/Utils.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/Utils.java
@@ -45,7 +45,6 @@ public class Utils {
         try {
             FilePath jfrogCliHomeDir = createAndGetJfrogCliHomeTempDir(ws, buildNumber);
             jfrogCliHomeDir.deleteRecursive();
-            taskListener.getLogger().println(jfrogCliHomeDir.getRemote() + " deleted");
         } catch (IOException | InterruptedException e) {
             taskListener.getLogger().println("Failed while attempting to delete the JFrog CLI home dir \n" + ExceptionUtils.getRootCauseMessage(e));
         }


### PR DESCRIPTION
- [x] This pull request is created in the [jfrog/jenkins-jfrog-plugin](https://github.com/jfrog/jenkins-jfrog-plugin) repository.

Fix https://github.com/jenkinsci/jfrog-plugin/issues/41

Remove the log message that indicates the deletion of `.jfrog` directory for each pipeline.
```
[Pipeline] End of Pipeline
/tmp/jenkins/workspace/testPipeline@tmp/jfrog/1/.jfrog deleted
```