### PR TITLE
Bump Jenkins version to 2.462.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.53</version>
+        <version>4.88</version>
     </parent>
 
     <properties>
-        <jenkins.version>2.361.4</jenkins.version>
+        <jenkins.version>2.462.3</jenkins.version>
         <skipITs>true</skipITs>
-        <buildinfo.version>2.37.2</buildinfo.version>
+        <buildinfo.version>2.41.23</buildinfo.version>
     </properties>
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>jfrog</artifactId>
@@ -188,24 +188,18 @@
         <dependency>
             <groupId>org.jfrog.filespecs</groupId>
             <artifactId>file-specs-java</artifactId>
-            <version>1.1.1</version>
+            <version>1.1.2</version>
         </dependency>
         <dependency>
             <groupId>org.jfrog.artifactory.client</groupId>
             <artifactId>artifactory-java-client-api</artifactId>
-            <version>2.13.0</version>
+            <version>2.19.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jfrog.artifactory.client</groupId>
             <artifactId>artifactory-java-client-services</artifactId>
-            <version>2.13.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.github.spotbugs</groupId>
-            <artifactId>spotbugs</artifactId>
-            <version>4.5.3</version>
+            <version>2.19.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -225,8 +219,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.361.x</artifactId>
-                <version>2102.v854b_fec19c92</version>
+                <artifactId>bom-2.462.x</artifactId>
+                <version>3387.v0f2773fa_3200</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -269,14 +263,13 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>4.5.3.0</version>
                 <configuration>
                     <excludeFilterFile>spotbugs-security-exclude.xml</excludeFilterFile>
                     <plugins>
                         <plugin>
                             <groupId>com.h3xstream.findsecbugs</groupId>
                             <artifactId>findsecbugs-plugin</artifactId>
-                            <version>1.12.0</version>
+                            <version>1.13.0</version>
                         </plugin>
                     </plugins>
                 </configuration>


### PR DESCRIPTION
- [x] This pull request is created in the [jfrog/jenkins-jfrog-plugin](https://github.com/jfrog/jenkins-jfrog-plugin) repository.

* Update Jenkins version to the latest LTS - 2.462.3
* Update other dependencies