### PR TITLE
Enhance JFrog CLI Credentials Input During Setup

### DIFF
--- a/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
@@ -83,8 +83,10 @@ public class JfStep extends Builder implements SimpleBuildStep {
     @Override
     public void perform(@NonNull Run<?, ?> run, @NonNull FilePath workspace, @NonNull EnvVars env, @NonNull Launcher launcher, @NonNull TaskListener listener) throws InterruptedException, IOException {
         workspace.mkdirs();
+
         this.isWindows = !launcher.isUnix();
         this.jfrogBinaryPath = getJFrogCLIPath(env, isWindows);
+        this.currentCliVersion = getJfrogCliVersion(launcher.launch().envs(env).pwd(workspace));
 
         // Build the 'jf' command
         ArgumentListBuilder builder = new ArgumentListBuilder();
@@ -167,7 +169,6 @@ public class JfStep extends Builder implements SimpleBuildStep {
         FilePath jfrogHomeTempDir = Utils.createAndGetJfrogCliHomeTempDir(workspace, String.valueOf(run.getNumber()));
         CliEnvConfigurator.configureCliEnv(env, jfrogHomeTempDir.getRemote(), jfrogCliConfigEncryption);
         Launcher.ProcStarter jfLauncher = launcher.launch().envs(env).pwd(workspace).stdout(listener);
-        this.currentCliVersion = getJfrogCliVersion(launcher.launch().envs(env).pwd(workspace));
         // Configure all servers, skip if all server ids have already been configured.
         if (shouldConfig(jfrogHomeTempDir)) {
             logIfNoToolProvided(env, listener);

--- a/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
@@ -320,7 +320,7 @@ public class JfStep extends Builder implements SimpleBuildStep {
     private void initClassValues(FilePath workspace, EnvVars env, Launcher launcher) throws IOException, InterruptedException {
         this.isWindows = !launcher.isUnix();
         this.jfrogBinaryPath = getJFrogCLIPath(env, isWindows);
-        this.passwordStdinSupported = isPasswordStdSupported(workspace, env, launcher);
+        this.passwordStdinSupported = isPasswordStdinSupported(workspace, env, launcher);
     }
 
     @Symbol("jf")
@@ -370,7 +370,7 @@ public class JfStep extends Builder implements SimpleBuildStep {
      * @param launcher  The command launcher.
      * @return true if stdin-based password handling is supported; false otherwise.
      */
-    public boolean isPasswordStdSupported(FilePath workspace, EnvVars env, Launcher launcher) throws IOException, InterruptedException {
+    public boolean isPasswordStdinSupported(FilePath workspace, EnvVars env, Launcher launcher) throws IOException, InterruptedException {
         // Determine if the launcher is a plugin (custom) launcher
         boolean isPluginLauncher = launcher.getClass().getName().contains("org.jenkinsci.plugins");
         if (isPluginLauncher) {

--- a/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
@@ -22,7 +22,6 @@ import io.jenkins.plugins.jfrog.configuration.JFrogPlatformInstance;
 import io.jenkins.plugins.jfrog.models.BuildInfoOutputModel;
 import io.jenkins.plugins.jfrog.plugins.PluginsUtils;
 import jenkins.tasks.SimpleBuildStep;
-import lombok.Getter;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
@@ -53,7 +52,6 @@ public class JfStep extends Builder implements SimpleBuildStep {
     private static final Version MIN_CLI_VERSION_PASSWORD_STDIN = new Version("2.31.3");
     static final String STEP_NAME = "jf";
 
-    @Getter
     protected String[] args;
     //  The current JFrog CLI version in the agent
     protected Version currentCliVersion;
@@ -72,6 +70,10 @@ public class JfStep extends Builder implements SimpleBuildStep {
             return;
         }
         this.args = split(args.toString());
+    }
+
+    public String[] getArgs() {
+        return args;
     }
 
     /**

--- a/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
@@ -167,7 +167,7 @@ public class JfStep extends Builder implements SimpleBuildStep {
         FilePath jfrogHomeTempDir = Utils.createAndGetJfrogCliHomeTempDir(workspace, String.valueOf(run.getNumber()));
         CliEnvConfigurator.configureCliEnv(env, jfrogHomeTempDir.getRemote(), jfrogCliConfigEncryption);
         Launcher.ProcStarter jfLauncher = launcher.launch().envs(env).pwd(workspace).stdout(listener);
-        this.currentCliVersion = getJfrogCliVersion(jfLauncher);
+        this.currentCliVersion = getJfrogCliVersion(launcher.launch().envs(env).pwd(workspace));
         // Configure all servers, skip if all server ids have already been configured.
         if (shouldConfig(jfrogHomeTempDir)) {
             logIfNoToolProvided(env, listener);

--- a/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
@@ -92,7 +92,6 @@ public class JfStep extends Builder implements SimpleBuildStep {
         try (ByteArrayOutputStream taskOutputStream = new ByteArrayOutputStream()) {
             JfTaskListener jfTaskListener = new JfTaskListener(listener, taskOutputStream);
             Launcher.ProcStarter jfLauncher = setupJFrogEnvironment(run, env, launcher, jfTaskListener, workspace, jfrogBinaryPath, isWindows);
-            this.currentCliVersion = getJfrogCliVersion(jfLauncher);
             // Running the 'jf' command
             int exitValue = jfLauncher.cmds(builder).join();
             if (exitValue != 0) {
@@ -171,6 +170,7 @@ public class JfStep extends Builder implements SimpleBuildStep {
             logIfNoToolProvided(env, listener);
             configAllServers(jfLauncher, jfrogBinaryPath, isWindows, run.getParent());
         }
+        this.currentCliVersion= getJfrogCliVersion(jfLauncher);
         return jfLauncher;
     }
 

--- a/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
@@ -50,8 +50,9 @@ import static org.jfrog.build.extractor.BuildInfoExtractorUtils.createMapper;
 @SuppressWarnings("unused")
 public class JfStep extends Builder implements SimpleBuildStep {
     private final ObjectMapper mapper = createMapper();
-    static final String STEP_NAME = "jf";
     private static final Version MIN_CLI_VERSION_PASSWORD_STDIN = new Version("2.31.3");
+    static final String STEP_NAME = "jf";
+
     @Getter
     protected String[] args;
     //  The current JFrog CLI version in the agent

--- a/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
@@ -329,19 +329,20 @@ public class JfStep extends Builder implements SimpleBuildStep {
         if (this.currentCliVersion != null) {
             return this.currentCliVersion;
         }
-        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        ArgumentListBuilder builder = new ArgumentListBuilder();
-        builder.add(jfrogBinaryPath).add("-v");
-        int exitCode = launcher
-                .cmds(builder)
-                .pwd(launcher.pwd())
-                .stdout(outputStream)
-                .join();
-        if (exitCode != 0) {
-            throw new IOException("Failed to get JFrog CLI version: " + outputStream.toString(StandardCharsets.UTF_8));
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()){
+            ArgumentListBuilder builder = new ArgumentListBuilder();
+            builder.add(jfrogBinaryPath).add("-v");
+            int exitCode = launcher
+                    .cmds(builder)
+                    .pwd(launcher.pwd())
+                    .stdout(outputStream)
+                    .join();
+            if (exitCode != 0) {
+                throw new IOException("Failed to get JFrog CLI version: " + outputStream.toString(StandardCharsets.UTF_8));
+            }
+            String versionOutput = outputStream.toString(StandardCharsets.UTF_8).trim();
+            String version = StringUtils.substringAfterLast(versionOutput, " ");
+            return new Version(version);
         }
-        String versionOutput = outputStream.toString(StandardCharsets.UTF_8).trim();
-        String version = StringUtils.substringAfterLast(versionOutput, " ");
-        return new Version(version);
     }
 }

--- a/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
@@ -216,7 +216,7 @@ public class JfStep extends Builder implements SimpleBuildStep {
         }
     }
 
-    private void addConfigArguments(ArgumentListBuilder builder, JFrogPlatformInstance jfrogPlatformInstance, String jfrogBinaryPath, Job<?, ?> job, Launcher.ProcStarter launcher) {
+    private void addConfigArguments(ArgumentListBuilder builder, JFrogPlatformInstance jfrogPlatformInstance, String jfrogBinaryPath, Job<?, ?> job, Launcher.ProcStarter launcher) throws IOException {
         String credentialsId = jfrogPlatformInstance.getCredentialsConfig().getCredentialsId();
         builder.add(jfrogBinaryPath).add("c").add("add").add(jfrogPlatformInstance.getId());
         // Add credentials
@@ -230,8 +230,9 @@ public class JfStep extends Builder implements SimpleBuildStep {
             // Use password-stdin if available
             if (this.currentCliVersion.isAtLeast(MIN_CLI_VERSION_PASSWORD_STDIN)) {
                 builder.add("--password-stdin");
-                ByteArrayInputStream inputStream = new ByteArrayInputStream(credentials.getPassword().getPlainText().getBytes(StandardCharsets.UTF_8));
-                launcher.stdin(inputStream);
+                try(ByteArrayInputStream inputStream = new ByteArrayInputStream(credentials.getPassword().getPlainText().getBytes(StandardCharsets.UTF_8))) {
+                    launcher.stdin(inputStream);
+                }
             } else {
                 builder.addMasked("--password=" + credentials.getPassword());
             }

--- a/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
@@ -36,7 +36,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.List;
-import java.util.Objects;
 
 import static io.jenkins.plugins.jfrog.JfrogInstallation.JFROG_BINARY_PATH;
 import static org.apache.commons.lang3.StringUtils.*;
@@ -309,7 +308,7 @@ public class JfStep extends Builder implements SimpleBuildStep {
     }
 
     String getJfrogCliVersion(Launcher.ProcStarter launcher) throws IOException, InterruptedException {
-        if (!Objects.equals(this.currentCliVersion, "")){
+        if (this.currentCliVersion != null && !this.currentCliVersion.isEmpty()) {
             return this.currentCliVersion;
         }
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();

--- a/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
@@ -81,6 +81,7 @@ public class JfStep extends Builder implements SimpleBuildStep {
     public void perform(@NonNull Run<?, ?> run, @NonNull FilePath workspace, @NonNull EnvVars env, @NonNull Launcher launcher, @NonNull TaskListener listener) throws InterruptedException, IOException {
         workspace.mkdirs();
         // Build the 'jf' command
+        this.currentCliVersion = getJfrogCliVersion(launcher.launch());
         ArgumentListBuilder builder = new ArgumentListBuilder();
         boolean isWindows = !launcher.isUnix();
         String jfrogBinaryPath = getJFrogCLIPath(env, isWindows);
@@ -170,7 +171,6 @@ public class JfStep extends Builder implements SimpleBuildStep {
             logIfNoToolProvided(env, listener);
             configAllServers(jfLauncher, jfrogBinaryPath, isWindows, run.getParent());
         }
-        this.currentCliVersion= getJfrogCliVersion(jfLauncher);
         return jfLauncher;
     }
 

--- a/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
@@ -148,11 +148,11 @@ public class JfStep extends Builder implements SimpleBuildStep {
     /**
      * Configure all JFrog relevant environment variables and all servers (if they haven't been configured yet).
      *
-     * @param run             running as part of a specific build
-     * @param env             environment variables applicable to this step
-     * @param launcher        a way to start processes
-     * @param listener        a place to send output
-     * @param workspace       a workspace to use for any file operations
+     * @param run       running as part of a specific build
+     * @param env       environment variables applicable to this step
+     * @param launcher  a way to start processes
+     * @param listener  a place to send output
+     * @param workspace a workspace to use for any file operations
      * @return launcher applicable to this step.
      * @throws InterruptedException if the step is interrupted
      * @throws IOException          in case of any I/O error, or we failed to run the 'jf' command
@@ -220,13 +220,12 @@ public class JfStep extends Builder implements SimpleBuildStep {
         builder.add(jfrogBinaryPath).add("c").add("add").add(jfrogPlatformInstance.getId());
         // Add credentials
         StringCredentials accessTokenCredentials = PluginsUtils.accessTokenCredentialsLookup(credentialsId, job);
+        // Access Token
         if (accessTokenCredentials != null) {
             builder.addMasked("--access-token=" + accessTokenCredentials.getSecret().getPlainText());
         } else {
             Credentials credentials = PluginsUtils.credentialsLookup(credentialsId, job);
             builder.add("--user=" + credentials.getUsername());
-
-
             // Use password-stdin if available
             if (isCliVersionGreaterThanOrEqual(this.currentCliVersion, MIN_CLI_VERSION_PASSWORD_STDIN)) {
                 builder.add("--password-stdin");
@@ -315,7 +314,7 @@ public class JfStep extends Builder implements SimpleBuildStep {
         }
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         ArgumentListBuilder builder = new ArgumentListBuilder();
-        builder.add(jfrogBinaryPath).add("--version");
+        builder.add(jfrogBinaryPath).add("-v");
         int exitCode = launcher
                 .cmds(builder)
                 .pwd(launcher.pwd())

--- a/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
@@ -61,7 +61,7 @@ public class JfStep extends Builder implements SimpleBuildStep {
     // True if the agent's OS is windows
     protected boolean isWindows;
     // Indicates the launcher type
-    private boolean isPluginLauncher;
+    protected boolean isPluginLauncher;
 
     @DataBoundConstructor
     public JfStep(Object args) {
@@ -225,7 +225,7 @@ public class JfStep extends Builder implements SimpleBuildStep {
         builder.add("--interactive=false").add("--overwrite=true");
     }
 
-    private void addCredentialsArguments(ArgumentListBuilder builder, JFrogPlatformInstance jfrogPlatformInstance, Job<?, ?> job, Launcher.ProcStarter launcher) throws IOException {
+    void addCredentialsArguments(ArgumentListBuilder builder, JFrogPlatformInstance jfrogPlatformInstance, Job<?, ?> job, Launcher.ProcStarter launcher) throws IOException {
         String credentialsId = jfrogPlatformInstance.getCredentialsConfig().getCredentialsId();
         StringCredentials accessTokenCredentials = PluginsUtils.accessTokenCredentialsLookup(credentialsId, job);
 

--- a/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
@@ -49,7 +49,7 @@ import static org.jfrog.build.extractor.BuildInfoExtractorUtils.createMapper;
 @SuppressWarnings("unused")
 public class JfStep extends Builder implements SimpleBuildStep {
     private final ObjectMapper mapper = createMapper();
-    private static final Version MIN_CLI_VERSION_PASSWORD_STDIN = new Version("2.31.3");
+    static final Version MIN_CLI_VERSION_PASSWORD_STDIN = new Version("2.31.3");
     static final String STEP_NAME = "jf";
 
     protected String[] args;
@@ -375,7 +375,7 @@ public class JfStep extends Builder implements SimpleBuildStep {
      * @param launcher  The command launcher.
      * @return true if stdin-based password handling is supported; false otherwise.
      */
-    private boolean isPasswordStdSupported(FilePath workspace, EnvVars env, Launcher launcher) throws IOException, InterruptedException {
+    public boolean isPasswordStdSupported(FilePath workspace, EnvVars env, Launcher launcher) throws IOException, InterruptedException {
         // Determine if the launcher is a plugin (custom) launcher
         boolean isPluginLauncher = launcher.getClass().getName().contains("org.jenkinsci.plugins");
         if (isPluginLauncher) {
@@ -383,7 +383,9 @@ public class JfStep extends Builder implements SimpleBuildStep {
         }
         // Check CLI version
         Launcher.ProcStarter procStarter = launcher.launch().envs(env).pwd(workspace);
-        this.currentCliVersion = getJfrogCliVersion(procStarter);
+        if (this.currentCliVersion == null) {
+            this.currentCliVersion = getJfrogCliVersion(procStarter);
+        }
         return this.currentCliVersion.isAtLeast(MIN_CLI_VERSION_PASSWORD_STDIN);
     }
 }

--- a/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
@@ -227,7 +227,7 @@ public class JfStep extends Builder implements SimpleBuildStep {
             // Use password-stdin if available
             if (isCliVersionGreaterThanOrEqual(cliVersion, MIN_CLI_VERSION_PASSWORD_STDIN)) {
                 builder.add("--password-stdin");
-                ByteArrayInputStream inputStream = new ByteArrayInputStream(credentials.getPassword().getPlainText().getBytes());
+                ByteArrayInputStream inputStream = new ByteArrayInputStream(credentials.getPassword().getPlainText().getBytes(StandardCharsets.UTF_8));
                 launcher.stdin(inputStream);
             } else {
                 builder.addMasked("--password=" + credentials.getPassword());

--- a/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
@@ -83,10 +83,8 @@ public class JfStep extends Builder implements SimpleBuildStep {
     @Override
     public void perform(@NonNull Run<?, ?> run, @NonNull FilePath workspace, @NonNull EnvVars env, @NonNull Launcher launcher, @NonNull TaskListener listener) throws InterruptedException, IOException {
         workspace.mkdirs();
-
-        this.isWindows = !launcher.isUnix();
-        this.jfrogBinaryPath = getJFrogCLIPath(env, isWindows);
-        this.currentCliVersion = getJfrogCliVersion(launcher.launch().envs(env).pwd(workspace));
+        // Initialize values to be used across the class
+        initClassValues(workspace, env, launcher);
 
         // Build the 'jf' command
         ArgumentListBuilder builder = new ArgumentListBuilder();
@@ -292,6 +290,21 @@ public class JfStep extends Builder implements SimpleBuildStep {
 
     private void logIllegalBuildPublishOutput(Log log, ByteArrayOutputStream taskOutputStream) {
         log.warn("Illegal build-publish output: " + taskOutputStream.toString(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * initialize values to be used across the class.
+     * @param env       environment variables applicable to this step
+     * @param launcher  a way to start processes
+     * @param workspace a workspace to use for any file operations
+     * @throws IOException in case of any I/O error, or we failed to run the 'jf'
+     * @throws InterruptedException if the step is interrupted
+     */
+    private void initClassValues(FilePath workspace, EnvVars env, Launcher launcher) throws IOException, InterruptedException {
+        this.isWindows = !launcher.isUnix();
+        this.jfrogBinaryPath = getJFrogCLIPath(env, isWindows);
+        Launcher.ProcStarter procStarter = launcher.launch().envs(env).pwd(workspace);
+        this.currentCliVersion = getJfrogCliVersion(procStarter);
     }
 
     @Symbol("jf")

--- a/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
@@ -81,7 +81,6 @@ public class JfStep extends Builder implements SimpleBuildStep {
     public void perform(@NonNull Run<?, ?> run, @NonNull FilePath workspace, @NonNull EnvVars env, @NonNull Launcher launcher, @NonNull TaskListener listener) throws InterruptedException, IOException {
         workspace.mkdirs();
         // Build the 'jf' command
-        this.currentCliVersion = getJfrogCliVersion(launcher.launch());
         ArgumentListBuilder builder = new ArgumentListBuilder();
         boolean isWindows = !launcher.isUnix();
         String jfrogBinaryPath = getJFrogCLIPath(env, isWindows);
@@ -166,6 +165,7 @@ public class JfStep extends Builder implements SimpleBuildStep {
         FilePath jfrogHomeTempDir = Utils.createAndGetJfrogCliHomeTempDir(workspace, String.valueOf(run.getNumber()));
         CliEnvConfigurator.configureCliEnv(env, jfrogHomeTempDir.getRemote(), jfrogCliConfigEncryption);
         Launcher.ProcStarter jfLauncher = launcher.launch().envs(env).pwd(workspace).stdout(listener);
+        this.currentCliVersion = getJfrogCliVersion(jfLauncher);
         // Configure all servers, skip if all server ids have already been configured.
         if (shouldConfig(jfrogHomeTempDir)) {
             logIfNoToolProvided(env, listener);

--- a/src/test/java/io/jenkins/plugins/jfrog/JfStepTest.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/JfStepTest.java
@@ -18,6 +18,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.stream.Stream;
 
+import static io.jenkins.plugins.jfrog.JfStep.MIN_CLI_VERSION_PASSWORD_STDIN;
 import static io.jenkins.plugins.jfrog.JfStep.getJFrogCLIPath;
 import static io.jenkins.plugins.jfrog.JfrogInstallation.JFROG_BINARY_PATH;
 import static org.junit.jupiter.api.Assertions.*;
@@ -90,7 +91,7 @@ public class JfStepTest {
      */
     @ParameterizedTest
     @MethodSource("provideTestArguments")
-    void testAddCredentialsArguments(String cliVersion, boolean isPluginLauncher, String expectedOutput) throws IOException {
+    void testAddCredentialsArguments(String cliVersion, boolean isPluginLauncher, String expectedOutput) throws IOException, InterruptedException {
         // Mock the necessary objects
         JFrogPlatformInstance jfrogPlatformInstance = mock(JFrogPlatformInstance.class);
         CredentialsConfig credentialsConfig = mock(CredentialsConfig.class);
@@ -103,9 +104,9 @@ public class JfStepTest {
 
         // Create an instance of JfStep
         JfStep jfStep = new JfStep("Mock Test");
+        // Mock CLI version
         jfStep.currentCliVersion = new Version(cliVersion);
-        jfStep.isPluginLauncher = isPluginLauncher;
-
+        jfStep.usePasswordFromStdin = jfStep.currentCliVersion.isAtLeast(MIN_CLI_VERSION_PASSWORD_STDIN) && !isPluginLauncher;
 
         // Create an ArgumentListBuilder
         ArgumentListBuilder builder = new ArgumentListBuilder();

--- a/src/test/java/io/jenkins/plugins/jfrog/JfStepTest.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/JfStepTest.java
@@ -3,7 +3,11 @@ package io.jenkins.plugins.jfrog;
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.Launcher;
+import hudson.model.Job;
 import hudson.util.ArgumentListBuilder;
+import io.jenkins.plugins.jfrog.configuration.CredentialsConfig;
+import io.jenkins.plugins.jfrog.configuration.JFrogPlatformInstance;
+import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 import org.jfrog.build.client.Version;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -19,18 +23,30 @@ import static io.jenkins.plugins.jfrog.JfStep.getJFrogCLIPath;
 import static io.jenkins.plugins.jfrog.JfrogInstallation.JFROG_BINARY_PATH;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
-/**
- * @author yahavi
- **/
 public class JfStepTest {
 
     @ParameterizedTest
     @MethodSource("jfrogCLIPathProvider")
     void getJFrogCLIPathTest(EnvVars inputEnvVars, boolean isWindows, String expectedOutput) {
         Assertions.assertEquals(expectedOutput, getJFrogCLIPath(inputEnvVars, isWindows));
+    }
+
+    private static Stream<Arguments> jfrogCLIPathProvider() {
+        return Stream.of(
+                // Unix agent
+                Arguments.of(new EnvVars(JFROG_BINARY_PATH, "a/b/c"), false, "a/b/c/jf"),
+                Arguments.of(new EnvVars(JFROG_BINARY_PATH, "a\\b\\c"), false, "a/b/c/jf"),
+                Arguments.of(new EnvVars(JFROG_BINARY_PATH, ""), false, "jf"),
+                Arguments.of(new EnvVars(), false, "jf"),
+
+                // Windows agent
+                Arguments.of(new EnvVars(JFROG_BINARY_PATH, "a/b/c"), true, "a\\b\\c\\jf.exe"),
+                Arguments.of(new EnvVars(JFROG_BINARY_PATH, "a\\b\\c"), true, "a\\b\\c\\jf.exe"),
+                Arguments.of(new EnvVars(JFROG_BINARY_PATH, ""), true, "jf.exe"),
+                Arguments.of(new EnvVars(), true, "jf.exe")
+        );
     }
 
     @Test
@@ -62,19 +78,61 @@ public class JfStepTest {
         assertEquals("2.31.0", version.toString());
     }
 
-    private static Stream<Arguments> jfrogCLIPathProvider() {
-        return Stream.of(
-                // Unix agent
-                Arguments.of(new EnvVars(JFROG_BINARY_PATH, "a/b/c"), false, "a/b/c/jf"),
-                Arguments.of(new EnvVars(JFROG_BINARY_PATH, "a\\b\\c"), false, "a/b/c/jf"),
-                Arguments.of(new EnvVars(JFROG_BINARY_PATH, ""), false, "jf"),
-                Arguments.of(new EnvVars(), false, "jf"),
+    /**
+     * Tests the addCredentialsArguments method logic with password-stdin vs.-- password flag.
+     * Password-stdin flag should only be set if the CLI version is supported
+     * AND the launcher is not the plugin launcher.
+     * Plugin launchers do not support password-stdin, as they do not have access to the standard input by default.
+     *
+     * @param cliVersion       The CLI version
+     * @param isPluginLauncher Whether the launcher is the plugin launcher
+     * @param expectedOutput   The expected output
+     * @throws IOException error
+     */
+    @ParameterizedTest
+    @MethodSource("provideTestArguments")
+    void testAddCredentialsArguments(String cliVersion, boolean isPluginLauncher, String expectedOutput) throws IOException {
+        // Mock the necessary objects
+        JFrogPlatformInstance jfrogPlatformInstance = mock(JFrogPlatformInstance.class);
+        CredentialsConfig credentialsConfig = mock(CredentialsConfig.class);
+        when(jfrogPlatformInstance.getId()).thenReturn("instance-id");
+        when(jfrogPlatformInstance.getCredentialsConfig()).thenReturn(credentialsConfig);
+        when(credentialsConfig.getCredentialsId()).thenReturn("credentials-id");
 
-                // Windows agent
-                Arguments.of(new EnvVars(JFROG_BINARY_PATH, "a/b/c"), true, "a\\b\\c\\jf.exe"),
-                Arguments.of(new EnvVars(JFROG_BINARY_PATH, "a\\b\\c"), true, "a\\b\\c\\jf.exe"),
-                Arguments.of(new EnvVars(JFROG_BINARY_PATH, ""), true, "jf.exe"),
-                Arguments.of(new EnvVars(), true, "jf.exe")
+        Job<?, ?> job = mock(Job.class);
+        Launcher.ProcStarter launcher = mock(Launcher.ProcStarter.class);
+        
+        // Create an instance of JfStep
+        JfStep jfStep = new JfStep("Mock Test");
+        jfStep.currentCliVersion = new Version(cliVersion);
+        jfStep.isPluginLauncher = isPluginLauncher;
+
+
+        // Create an ArgumentListBuilder
+        ArgumentListBuilder builder = new ArgumentListBuilder();
+
+        // Call the addCredentialsArguments method
+        jfStep.addCredentialsArguments(builder, jfrogPlatformInstance, job, launcher);
+
+        // Verify the arguments
+        assertTrue(builder.toList().contains(expectedOutput));
+    }
+
+    private static Stream<Arguments> provideTestArguments() {
+        String passwordFlag = "--password=";
+        String passwordStdinFlag = "--password-stdin";
+        // Min version for password stdin is 2.31.3
+        return Stream.of(
+                // Supported CLI version but Plugin Launcher
+                Arguments.of("2.57.0", true, passwordFlag),
+                // Unsupported Version
+                Arguments.of("2.31.0", false, passwordFlag),
+                // Supported CLI version and local launcher
+                Arguments.of("2.57.0", false, passwordStdinFlag),
+                // Unsupported CLI version and Plugin Launcher
+                Arguments.of("2.31.0", true, passwordFlag),
+                // Minimum supported CLI version for password stdin
+                Arguments.of("2.31.3", false, passwordStdinFlag)
         );
     }
 }

--- a/src/test/java/io/jenkins/plugins/jfrog/JfStepTest.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/JfStepTest.java
@@ -101,7 +101,7 @@ public class JfStepTest {
 
         Job<?, ?> job = mock(Job.class);
         Launcher.ProcStarter launcher = mock(Launcher.ProcStarter.class);
-        
+
         // Create an instance of JfStep
         JfStep jfStep = new JfStep("Mock Test");
         jfStep.currentCliVersion = new Version(cliVersion);

--- a/src/test/java/io/jenkins/plugins/jfrog/JfStepTest.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/JfStepTest.java
@@ -4,6 +4,7 @@ import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.util.ArgumentListBuilder;
+import org.jfrog.build.client.Version;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -33,24 +34,6 @@ public class JfStepTest {
     }
 
     @Test
-    void isCliVersionGreaterThanTest() {
-        JfStep jfStep = new JfStep("--version");
-
-        // Test cases where the current version is greater
-        assertTrue(jfStep.isCliVersionGreaterThanOrEqual("2.32.0", "2.31.0"));
-        assertTrue(jfStep.isCliVersionGreaterThanOrEqual("3.0.0", "2.31.0"));
-        assertTrue(jfStep.isCliVersionGreaterThanOrEqual("2.31.1", "2.31.0"));
-
-        // Test cases where the current version is equal
-        assertTrue(jfStep.isCliVersionGreaterThanOrEqual("2.31.0", "2.31.0"));
-
-        // Test cases where the current version is less
-        assertFalse(jfStep.isCliVersionGreaterThanOrEqual("2.30.0", "2.31.0"));
-        assertFalse(jfStep.isCliVersionGreaterThanOrEqual("2.31.0", "2.31.1"));
-        assertFalse(jfStep.isCliVersionGreaterThanOrEqual("1.31.0", "2.31.0"));
-    }
-
-    @Test
     void getJfrogCliVersionTest() throws IOException, InterruptedException {
         // Mock the Launcher
         Launcher launcher = mock(Launcher.class);
@@ -73,10 +56,10 @@ public class JfStepTest {
         // Create an instance of JfStep and call the method
         JfStep jfStep = new JfStep("--version");
         jfStep.isWindows = System.getProperty("os.name").toLowerCase().contains("win");
-        String version = jfStep.getJfrogCliVersion(procStarter);
+        Version version = jfStep.getJfrogCliVersion(procStarter);
 
         // Verify the result
-        assertEquals("2.31.0", version);
+        assertEquals("2.31.0", version.toString());
     }
 
     private static Stream<Arguments> jfrogCLIPathProvider() {

--- a/src/test/java/io/jenkins/plugins/jfrog/JfStepTest.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/JfStepTest.java
@@ -1,15 +1,24 @@
 package io.jenkins.plugins.jfrog;
 
 import hudson.EnvVars;
+import hudson.FilePath;
+import hudson.Launcher;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.stream.Stream;
 
 import static io.jenkins.plugins.jfrog.JfStep.getJFrogCLIPath;
 import static io.jenkins.plugins.jfrog.JfrogInstallation.JFROG_BINARY_PATH;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * @author yahavi
@@ -20,6 +29,49 @@ public class JfStepTest {
     @MethodSource("jfrogCLIPathProvider")
     void getJFrogCLIPathTest(EnvVars inputEnvVars, boolean isWindows, String expectedOutput) {
         Assertions.assertEquals(expectedOutput, getJFrogCLIPath(inputEnvVars, isWindows));
+    }
+
+    @Test
+    void isCliVersionGreaterThanTest() {
+        JfStep jfStep = new JfStep("--version");
+
+        // Test cases where the current version is greater
+        assertTrue(jfStep.isCliVersionGreaterThanOrEqual("2.32.0", "2.31.0"));
+        assertTrue(jfStep.isCliVersionGreaterThanOrEqual("3.0.0", "2.31.0"));
+        assertTrue(jfStep.isCliVersionGreaterThanOrEqual("2.31.1", "2.31.0"));
+
+        // Test cases where the current version is equal
+        assertTrue(jfStep.isCliVersionGreaterThanOrEqual("2.31.0", "2.31.0"));
+
+        // Test cases where the current version is less
+        assertFalse(jfStep.isCliVersionGreaterThanOrEqual("2.30.0", "2.31.0"));
+        assertFalse(jfStep.isCliVersionGreaterThanOrEqual("2.31.0", "2.31.1"));
+        assertFalse(jfStep.isCliVersionGreaterThanOrEqual("1.31.0", "2.31.0"));
+    }
+
+    @Test
+    void getJfrogCliVersionTest() throws IOException, InterruptedException {
+        // Mock the Launcher.ProcStarter
+        Launcher.ProcStarter procStarter = mock(Launcher.ProcStarter.class);
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        // Mocks the return value of --version command
+        outputStream.write("jf version 2.31.0 ".getBytes());
+        // Mock the behavior of the ProcStarter
+        when(procStarter.cmds("jf", "--version")).thenReturn(procStarter);
+        when(procStarter.pwd((FilePath) any())).thenReturn(procStarter);
+        when(procStarter.stdout(any(ByteArrayOutputStream.class))).thenAnswer(invocation -> {
+            ByteArrayOutputStream out = invocation.getArgument(0);
+            out.write(outputStream.toByteArray());
+            return procStarter;
+        });
+        when(procStarter.join()).thenReturn(0);
+
+        // Create an instance of JfStep and call the method
+        JfStep jfStep = new JfStep("--version");
+        String version = jfStep.getJfrogCliVersion(procStarter);
+
+        // Verify the result
+        assertEquals("2.31.0", version);
     }
 
     private static Stream<Arguments> jfrogCLIPathProvider() {

--- a/src/test/java/io/jenkins/plugins/jfrog/JfStepTest.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/JfStepTest.java
@@ -91,7 +91,7 @@ public class JfStepTest {
      */
     @ParameterizedTest
     @MethodSource("provideTestArguments")
-    void testAddCredentialsArguments(String cliVersion, boolean isPluginLauncher, String expectedOutput) throws IOException, InterruptedException {
+    void testAddCredentialsArguments(String cliVersion, boolean isPluginLauncher, String expectedOutput) throws IOException {
         // Mock the necessary objects
         JFrogPlatformInstance jfrogPlatformInstance = mock(JFrogPlatformInstance.class);
         CredentialsConfig credentialsConfig = mock(CredentialsConfig.class);
@@ -104,9 +104,8 @@ public class JfStepTest {
 
         // Create an instance of JfStep
         JfStep jfStep = new JfStep("Mock Test");
-        // Mock CLI version
-        jfStep.currentCliVersion = new Version(cliVersion);
-        jfStep.usePasswordFromStdin = jfStep.currentCliVersion.isAtLeast(MIN_CLI_VERSION_PASSWORD_STDIN) && !isPluginLauncher;
+        // Mock password stdin supported or not.
+        jfStep.passwordStdinSupported = new Version(cliVersion).isAtLeast(MIN_CLI_VERSION_PASSWORD_STDIN) && !isPluginLauncher;
 
         // Create an ArgumentListBuilder
         ArgumentListBuilder builder = new ArgumentListBuilder();

--- a/src/test/java/io/jenkins/plugins/jfrog/JfStepTest.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/JfStepTest.java
@@ -68,7 +68,7 @@ public class JfStepTest {
 
         // Create an instance of JfStep and call the method
         JfStep jfStep = new JfStep("--version");
-        String version = jfStep.getJfrogCliVersion(procStarter);
+        String version = jfStep.getJfrogCliVersion(procStarter, getJFrogCLIPath(new EnvVars(),false));
 
         // Verify the result
         assertEquals("2.31.0", version);

--- a/src/test/java/io/jenkins/plugins/jfrog/JfStepTest.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/JfStepTest.java
@@ -7,7 +7,6 @@ import hudson.model.Job;
 import hudson.util.ArgumentListBuilder;
 import io.jenkins.plugins.jfrog.configuration.CredentialsConfig;
 import io.jenkins.plugins.jfrog.configuration.JFrogPlatformInstance;
-import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 import org.jfrog.build.client.Version;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/io/jenkins/plugins/jfrog/JfStepTest.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/JfStepTest.java
@@ -3,6 +3,7 @@ package io.jenkins.plugins.jfrog;
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.Launcher;
+import hudson.util.ArgumentListBuilder;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -51,13 +52,17 @@ public class JfStepTest {
 
     @Test
     void getJfrogCliVersionTest() throws IOException, InterruptedException {
+        boolean isWindows = System.getProperty("os.name").toLowerCase().contains("win");
+        // Mock the Launcher
+        Launcher launcher = mock(Launcher.class);
         // Mock the Launcher.ProcStarter
         Launcher.ProcStarter procStarter = mock(Launcher.ProcStarter.class);
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         // Mocks the return value of --version command
         outputStream.write("jf version 2.31.0 ".getBytes());
-        // Mock the behavior of the ProcStarter
-        when(procStarter.cmds("jf", "--version")).thenReturn(procStarter);
+        // Mock the behavior of the Launcher and ProcStarter
+        when(launcher.launch()).thenReturn(procStarter);
+        when(procStarter.cmds(any(ArgumentListBuilder.class))).thenReturn(procStarter);
         when(procStarter.pwd((FilePath) any())).thenReturn(procStarter);
         when(procStarter.stdout(any(ByteArrayOutputStream.class))).thenAnswer(invocation -> {
             ByteArrayOutputStream out = invocation.getArgument(0);
@@ -68,7 +73,7 @@ public class JfStepTest {
 
         // Create an instance of JfStep and call the method
         JfStep jfStep = new JfStep("--version");
-        String version = jfStep.getJfrogCliVersion(procStarter, getJFrogCLIPath(new EnvVars(),false));
+        String version = jfStep.getJfrogCliVersion(procStarter, JfStep.getJFrogCLIPath(new EnvVars(), isWindows));
 
         // Verify the result
         assertEquals("2.31.0", version);

--- a/src/test/java/io/jenkins/plugins/jfrog/JfStepTest.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/JfStepTest.java
@@ -52,7 +52,6 @@ public class JfStepTest {
 
     @Test
     void getJfrogCliVersionTest() throws IOException, InterruptedException {
-        boolean isWindows = System.getProperty("os.name").toLowerCase().contains("win");
         // Mock the Launcher
         Launcher launcher = mock(Launcher.class);
         // Mock the Launcher.ProcStarter
@@ -73,7 +72,8 @@ public class JfStepTest {
 
         // Create an instance of JfStep and call the method
         JfStep jfStep = new JfStep("--version");
-        String version = jfStep.getJfrogCliVersion(procStarter, JfStep.getJFrogCLIPath(new EnvVars(), isWindows));
+        jfStep.isWindows = System.getProperty("os.name").toLowerCase().contains("win");
+        String version = jfStep.getJfrogCliVersion(procStarter);
 
         // Verify the result
         assertEquals("2.31.0", version);

--- a/src/test/java/io/jenkins/plugins/jfrog/integration/JFrogInstallationITest.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/integration/JFrogInstallationITest.java
@@ -54,8 +54,7 @@ class JFrogInstallationITest extends PipelineTestBase {
         // Download the latest CLI version.
         // Using remote repository to 'releases.jfrog.io' in the client's Artifactory.
         configureJfrogCliFromArtifactory(JFROG_CLI_TOOL_NAME_1, TEST_CONFIGURED_SERVER_ID, getRepoKey(TestRepository.CLI_REMOTE_REPO), true);
-        WorkflowRun job = runPipeline(jenkins, "basic_version_command");
-        assertTrue(job.getLog().contains("jf version "));
+        runPipeline(jenkins, "basic_version_command");
     }
 
     // Gets JfrogInstallation directory in Jenkins work root.

--- a/src/test/java/io/jenkins/plugins/jfrog/integration/JFrogInstallationITest.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/integration/JFrogInstallationITest.java
@@ -54,7 +54,8 @@ class JFrogInstallationITest extends PipelineTestBase {
         // Download the latest CLI version.
         // Using remote repository to 'releases.jfrog.io' in the client's Artifactory.
         configureJfrogCliFromArtifactory(JFROG_CLI_TOOL_NAME_1, TEST_CONFIGURED_SERVER_ID, getRepoKey(TestRepository.CLI_REMOTE_REPO), true);
-        runPipeline(jenkins, "basic_version_command");
+        WorkflowRun job = runPipeline(jenkins, "basic_version_command");
+        assertTrue(job.getLog().contains("jf version "));
     }
 
     // Gets JfrogInstallation directory in Jenkins work root.

--- a/src/test/java/io/jenkins/plugins/jfrog/integration/PipelineTestBase.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/integration/PipelineTestBase.java
@@ -19,7 +19,6 @@ import io.jenkins.plugins.jfrog.ArtifactoryInstaller;
 import io.jenkins.plugins.jfrog.BinaryInstaller;
 import io.jenkins.plugins.jfrog.JfrogInstallation;
 import io.jenkins.plugins.jfrog.ReleasesInstaller;
-import io.jenkins.plugins.jfrog.configuration.Credentials;
 import io.jenkins.plugins.jfrog.configuration.CredentialsConfig;
 import io.jenkins.plugins.jfrog.configuration.JFrogPlatformBuilder;
 import io.jenkins.plugins.jfrog.configuration.JFrogPlatformInstance;
@@ -161,12 +160,12 @@ public class PipelineTestBase {
     private void setGlobalConfiguration() throws IOException {
         JFrogPlatformBuilder.DescriptorImpl jfrogBuilder = (JFrogPlatformBuilder.DescriptorImpl) jenkins.getInstance().getDescriptor(JFrogPlatformBuilder.class);
         Assert.assertNotNull(jfrogBuilder);
-        CredentialsConfig emptyCred = new CredentialsConfig(StringUtils.EMPTY, Credentials.EMPTY_CREDENTIALS);
         CredentialsConfig platformCred = new CredentialsConfig(Secret.fromString(ARTIFACTORY_USERNAME), Secret.fromString(ARTIFACTORY_PASSWORD), Secret.fromString(ACCESS_TOKEN), "credentials");
-        List<JFrogPlatformInstance> artifactoryServers = new ArrayList<JFrogPlatformInstance>() {{
+        CredentialsConfig secondPlatformCred = new CredentialsConfig(Secret.fromString(ARTIFACTORY_USERNAME), Secret.fromString(ARTIFACTORY_PASSWORD), Secret.fromString(ACCESS_TOKEN), "credentials");
+        List<JFrogPlatformInstance> artifactoryServers = new ArrayList<>() {{
             // Dummy server to test multiple configured servers.
             // The dummy server should be configured first to ensure the right server is being used (and not the first one).
-            add(new JFrogPlatformInstance("dummyServerId", "", emptyCred, "", "", ""));
+            add(new JFrogPlatformInstance("dummyServerId", "", secondPlatformCred, "", "", ""));
             add(new JFrogPlatformInstance(TEST_CONFIGURED_SERVER_ID, PLATFORM_URL, platformCred, ARTIFACTORY_URL, "", ""));
         }};
         jfrogBuilder.setJfrogInstances(artifactoryServers);

--- a/src/test/java/io/jenkins/plugins/jfrog/integration/PipelineTestBase.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/integration/PipelineTestBase.java
@@ -69,6 +69,7 @@ public class PipelineTestBase {
     static final String JFROG_CLI_TOOL_NAME_1 = "jfrog-cli";
     static final String JFROG_CLI_TOOL_NAME_2 = "jfrog-cli-2";
     static final String TEST_CONFIGURED_SERVER_ID = "serverId";
+    static final String TEST_CONFIGURED_DUMMY_SERVER_ID = "dummyId";
 
     // Set up jenkins and configure latest JFrog CLI.
     public void initPipelineTest(JenkinsRule jenkins) throws Exception {
@@ -161,12 +162,12 @@ public class PipelineTestBase {
     private void setGlobalConfiguration() throws IOException {
         JFrogPlatformBuilder.DescriptorImpl jfrogBuilder = (JFrogPlatformBuilder.DescriptorImpl) jenkins.getInstance().getDescriptor(JFrogPlatformBuilder.class);
         Assert.assertNotNull(jfrogBuilder);
-        CredentialsConfig emptyCred = new CredentialsConfig(StringUtils.EMPTY, Credentials.EMPTY_CREDENTIALS);
+        CredentialsConfig emptyCred = new CredentialsConfig(StringUtils.EMPTY,  new Credentials(Secret.fromString("username"), Secret.fromString("123"), null));
         CredentialsConfig platformCred = new CredentialsConfig(Secret.fromString(ARTIFACTORY_USERNAME), Secret.fromString(ARTIFACTORY_PASSWORD), Secret.fromString(ACCESS_TOKEN), "credentials");
         List<JFrogPlatformInstance> artifactoryServers = new ArrayList<JFrogPlatformInstance>() {{
             // Dummy server to test multiple configured servers.
             // The dummy server should be configured first to ensure the right server is being used (and not the first one).
-            add(new JFrogPlatformInstance("dummyServerId", "", emptyCred, "", "", ""));
+            add(new JFrogPlatformInstance(TEST_CONFIGURED_DUMMY_SERVER_ID, PLATFORM_URL, platformCred, ARTIFACTORY_URL, "", ""));
             add(new JFrogPlatformInstance(TEST_CONFIGURED_SERVER_ID, PLATFORM_URL, platformCred, ARTIFACTORY_URL, "", ""));
         }};
         jfrogBuilder.setJfrogInstances(artifactoryServers);

--- a/src/test/java/io/jenkins/plugins/jfrog/integration/PipelineTestBase.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/integration/PipelineTestBase.java
@@ -19,6 +19,7 @@ import io.jenkins.plugins.jfrog.ArtifactoryInstaller;
 import io.jenkins.plugins.jfrog.BinaryInstaller;
 import io.jenkins.plugins.jfrog.JfrogInstallation;
 import io.jenkins.plugins.jfrog.ReleasesInstaller;
+import io.jenkins.plugins.jfrog.configuration.Credentials;
 import io.jenkins.plugins.jfrog.configuration.CredentialsConfig;
 import io.jenkins.plugins.jfrog.configuration.JFrogPlatformBuilder;
 import io.jenkins.plugins.jfrog.configuration.JFrogPlatformInstance;
@@ -160,10 +161,12 @@ public class PipelineTestBase {
     private void setGlobalConfiguration() throws IOException {
         JFrogPlatformBuilder.DescriptorImpl jfrogBuilder = (JFrogPlatformBuilder.DescriptorImpl) jenkins.getInstance().getDescriptor(JFrogPlatformBuilder.class);
         Assert.assertNotNull(jfrogBuilder);
+        CredentialsConfig emptyCred = new CredentialsConfig(StringUtils.EMPTY, Credentials.EMPTY_CREDENTIALS);
         CredentialsConfig platformCred = new CredentialsConfig(Secret.fromString(ARTIFACTORY_USERNAME), Secret.fromString(ARTIFACTORY_PASSWORD), Secret.fromString(ACCESS_TOKEN), "credentials");
-        List<JFrogPlatformInstance> artifactoryServers = new ArrayList<>() {{
+        List<JFrogPlatformInstance> artifactoryServers = new ArrayList<JFrogPlatformInstance>() {{
             // Dummy server to test multiple configured servers.
             // The dummy server should be configured first to ensure the right server is being used (and not the first one).
+            add(new JFrogPlatformInstance("dummyServerId", "", emptyCred, "", "", ""));
             add(new JFrogPlatformInstance(TEST_CONFIGURED_SERVER_ID, PLATFORM_URL, platformCred, ARTIFACTORY_URL, "", ""));
         }};
         jfrogBuilder.setJfrogInstances(artifactoryServers);

--- a/src/test/java/io/jenkins/plugins/jfrog/integration/PipelineTestBase.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/integration/PipelineTestBase.java
@@ -69,7 +69,6 @@ public class PipelineTestBase {
     static final String JFROG_CLI_TOOL_NAME_1 = "jfrog-cli";
     static final String JFROG_CLI_TOOL_NAME_2 = "jfrog-cli-2";
     static final String TEST_CONFIGURED_SERVER_ID = "serverId";
-    static final String TEST_CONFIGURED_DUMMY_SERVER_ID = "dummyId";
 
     // Set up jenkins and configure latest JFrog CLI.
     public void initPipelineTest(JenkinsRule jenkins) throws Exception {
@@ -162,12 +161,10 @@ public class PipelineTestBase {
     private void setGlobalConfiguration() throws IOException {
         JFrogPlatformBuilder.DescriptorImpl jfrogBuilder = (JFrogPlatformBuilder.DescriptorImpl) jenkins.getInstance().getDescriptor(JFrogPlatformBuilder.class);
         Assert.assertNotNull(jfrogBuilder);
-        CredentialsConfig emptyCred = new CredentialsConfig(StringUtils.EMPTY,  new Credentials(Secret.fromString("username"), Secret.fromString("123"), null));
         CredentialsConfig platformCred = new CredentialsConfig(Secret.fromString(ARTIFACTORY_USERNAME), Secret.fromString(ARTIFACTORY_PASSWORD), Secret.fromString(ACCESS_TOKEN), "credentials");
         List<JFrogPlatformInstance> artifactoryServers = new ArrayList<JFrogPlatformInstance>() {{
             // Dummy server to test multiple configured servers.
             // The dummy server should be configured first to ensure the right server is being used (and not the first one).
-            add(new JFrogPlatformInstance(TEST_CONFIGURED_DUMMY_SERVER_ID, PLATFORM_URL, platformCred, ARTIFACTORY_URL, "", ""));
             add(new JFrogPlatformInstance(TEST_CONFIGURED_SERVER_ID, PLATFORM_URL, platformCred, ARTIFACTORY_URL, "", ""));
         }};
         jfrogBuilder.setJfrogInstances(artifactoryServers);

--- a/src/test/java/io/jenkins/plugins/jfrog/integration/PipelineTestBase.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/integration/PipelineTestBase.java
@@ -19,7 +19,6 @@ import io.jenkins.plugins.jfrog.ArtifactoryInstaller;
 import io.jenkins.plugins.jfrog.BinaryInstaller;
 import io.jenkins.plugins.jfrog.JfrogInstallation;
 import io.jenkins.plugins.jfrog.ReleasesInstaller;
-import io.jenkins.plugins.jfrog.configuration.Credentials;
 import io.jenkins.plugins.jfrog.configuration.CredentialsConfig;
 import io.jenkins.plugins.jfrog.configuration.JFrogPlatformBuilder;
 import io.jenkins.plugins.jfrog.configuration.JFrogPlatformInstance;
@@ -161,12 +160,10 @@ public class PipelineTestBase {
     private void setGlobalConfiguration() throws IOException {
         JFrogPlatformBuilder.DescriptorImpl jfrogBuilder = (JFrogPlatformBuilder.DescriptorImpl) jenkins.getInstance().getDescriptor(JFrogPlatformBuilder.class);
         Assert.assertNotNull(jfrogBuilder);
-        CredentialsConfig emptyCred = new CredentialsConfig(StringUtils.EMPTY, Credentials.EMPTY_CREDENTIALS);
         CredentialsConfig platformCred = new CredentialsConfig(Secret.fromString(ARTIFACTORY_USERNAME), Secret.fromString(ARTIFACTORY_PASSWORD), Secret.fromString(ACCESS_TOKEN), "credentials");
-        List<JFrogPlatformInstance> artifactoryServers = new ArrayList<JFrogPlatformInstance>() {{
+        List<JFrogPlatformInstance> artifactoryServers = new ArrayList<>() {{
             // Dummy server to test multiple configured servers.
             // The dummy server should be configured first to ensure the right server is being used (and not the first one).
-            add(new JFrogPlatformInstance("dummyServerId", "", emptyCred, "", "", ""));
             add(new JFrogPlatformInstance(TEST_CONFIGURED_SERVER_ID, PLATFORM_URL, platformCred, ARTIFACTORY_URL, "", ""));
         }};
         jfrogBuilder.setJfrogInstances(artifactoryServers);

--- a/src/test/java/io/jenkins/plugins/jfrog/integration/PipelineTestBase.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/integration/PipelineTestBase.java
@@ -161,10 +161,12 @@ public class PipelineTestBase {
     private void setGlobalConfiguration() throws IOException {
         JFrogPlatformBuilder.DescriptorImpl jfrogBuilder = (JFrogPlatformBuilder.DescriptorImpl) jenkins.getInstance().getDescriptor(JFrogPlatformBuilder.class);
         Assert.assertNotNull(jfrogBuilder);
+        CredentialsConfig emptyCred = new CredentialsConfig(StringUtils.EMPTY, Credentials.EMPTY_CREDENTIALS);
         CredentialsConfig platformCred = new CredentialsConfig(Secret.fromString(ARTIFACTORY_USERNAME), Secret.fromString(ARTIFACTORY_PASSWORD), Secret.fromString(ACCESS_TOKEN), "credentials");
         List<JFrogPlatformInstance> artifactoryServers = new ArrayList<JFrogPlatformInstance>() {{
             // Dummy server to test multiple configured servers.
             // The dummy server should be configured first to ensure the right server is being used (and not the first one).
+            add(new JFrogPlatformInstance("dummyServerId", "", emptyCred, "", "", ""));
             add(new JFrogPlatformInstance(TEST_CONFIGURED_SERVER_ID, PLATFORM_URL, platformCred, ARTIFACTORY_URL, "", ""));
         }};
         jfrogBuilder.setJfrogInstances(artifactoryServers);

--- a/src/test/java/io/jenkins/plugins/jfrog/integration/PipelineTestBase.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/integration/PipelineTestBase.java
@@ -68,6 +68,7 @@ public class PipelineTestBase {
     static final String JFROG_CLI_TOOL_NAME_1 = "jfrog-cli";
     static final String JFROG_CLI_TOOL_NAME_2 = "jfrog-cli-2";
     static final String TEST_CONFIGURED_SERVER_ID = "serverId";
+    static final String TEST_CONFIGURED_SERVER_ID_2 = "serverId2";
 
     // Set up jenkins and configure latest JFrog CLI.
     public void initPipelineTest(JenkinsRule jenkins) throws Exception {
@@ -161,12 +162,10 @@ public class PipelineTestBase {
         JFrogPlatformBuilder.DescriptorImpl jfrogBuilder = (JFrogPlatformBuilder.DescriptorImpl) jenkins.getInstance().getDescriptor(JFrogPlatformBuilder.class);
         Assert.assertNotNull(jfrogBuilder);
         CredentialsConfig platformCred = new CredentialsConfig(Secret.fromString(ARTIFACTORY_USERNAME), Secret.fromString(ARTIFACTORY_PASSWORD), Secret.fromString(ACCESS_TOKEN), "credentials");
-        CredentialsConfig secondPlatformCred = new CredentialsConfig(Secret.fromString(ARTIFACTORY_USERNAME), Secret.fromString(ARTIFACTORY_PASSWORD), Secret.fromString(ACCESS_TOKEN), "credentials");
         List<JFrogPlatformInstance> artifactoryServers = new ArrayList<>() {{
-            // Dummy server to test multiple configured servers.
-            // The dummy server should be configured first to ensure the right server is being used (and not the first one).
-            add(new JFrogPlatformInstance("dummyServerId", "", secondPlatformCred, "", "", ""));
+            // Configure multiple servers to test multiple servers.
             add(new JFrogPlatformInstance(TEST_CONFIGURED_SERVER_ID, PLATFORM_URL, platformCred, ARTIFACTORY_URL, "", ""));
+            add(new JFrogPlatformInstance(TEST_CONFIGURED_SERVER_ID_2, PLATFORM_URL, platformCred, ARTIFACTORY_URL, "", ""));
         }};
         jfrogBuilder.setJfrogInstances(artifactoryServers);
         Jenkins.get().getDescriptorByType(JFrogPlatformBuilder.DescriptorImpl.class).setJfrogInstances(artifactoryServers);


### PR DESCRIPTION
- [x] This pull request is created in the [jfrog/jenkins-jfrog-plugin](https://github.com/jfrog/jenkins-jfrog-plugin) repository.

Utilise the --password-stdin flag if supported CLI version is being used.

**When is it possible?**
1. CLI version supported.
2. No custom launcher is used.

When a custom launcher is being used, the stdin we prepare in the plugin does not gets passed to the custom launchers, for example docker launchers. 
