### PR TITLE
Enhance JFrog CLI Credentials Input During Setup

### DIFF
--- a/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
@@ -110,8 +110,6 @@ public class JfStep extends Step {
 
             // Build the 'jf' command
             ArgumentListBuilder builder = new ArgumentListBuilder();
-            boolean isWindows = !launcher.isUnix();
-            String jfrogBinaryPath = getJFrogCLIPath(env, isWindows);
 
             builder.add(jfrogBinaryPath).add(args);
             if (isWindows) {

--- a/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
@@ -289,13 +289,6 @@ public class JfStep extends Step {
         }
     }
 
-    private void addConfigArguments(ArgumentListBuilder builder, JFrogPlatformInstance jfrogPlatformInstance, String jfrogBinaryPath, Job<?, ?> job, Launcher.ProcStarter launcher) throws IOException {
-        builder.add(jfrogBinaryPath).add("c").add("add").add(jfrogPlatformInstance.getId());
-        addCredentialsArguments(builder, jfrogPlatformInstance, job, launcher);
-        addUrlArguments(builder, jfrogPlatformInstance);
-        builder.add("--interactive=false").add("--overwrite=true");
-    }
-
     static void addCredentialsArguments(ArgumentListBuilder builder, JFrogPlatformInstance jfrogPlatformInstance, Job<?, ?> job, Launcher.ProcStarter launcher) throws IOException {
         String credentialsId = jfrogPlatformInstance.getCredentialsConfig().getCredentialsId();
         StringCredentials accessTokenCredentials = PluginsUtils.accessTokenCredentialsLookup(credentialsId, job);
@@ -313,7 +306,7 @@ public class JfStep extends Step {
     // Stdin support requires a minimum CLI version and excludes plugin launchers.
     // Plugin launchers may lose stdin input, causing command failure;
     // hence, stdin is unsupported without plugin-specific handling.
-    private static void addPasswordArgument(ArgumentListBuilder builder, Credentials credentials, Launcher.ProcStarter launcher) throws IOException {
+    static void addPasswordArgument(ArgumentListBuilder builder, Credentials credentials, Launcher.ProcStarter launcher) throws IOException {
         if (passwordStdinSupported) {
             // Use stdin
             builder.add("--password-stdin");
@@ -326,7 +319,7 @@ public class JfStep extends Step {
         }
     }
 
-    private static void addUrlArguments(ArgumentListBuilder builder, JFrogPlatformInstance jfrogPlatformInstance) {
+    static void addUrlArguments(ArgumentListBuilder builder, JFrogPlatformInstance jfrogPlatformInstance) {
         builder.add("--url=" + jfrogPlatformInstance.getUrl());
         builder.add("--artifactory-url=" + jfrogPlatformInstance.inferArtifactoryUrl());
         builder.add("--distribution-url=" + jfrogPlatformInstance.inferDistributionUrl());

--- a/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
@@ -47,11 +47,11 @@ public class JfStep extends Step {
     protected String[] args;
     static final Version MIN_CLI_VERSION_PASSWORD_STDIN = new Version("2.31.3");
     // The JFrog CLI binary path in the agent
-    protected static String jfrogBinaryPath;
+    static String jfrogBinaryPath;
     // True if the agent's OS is windows
-    protected static boolean isWindows;
+    static boolean isWindows;
     // Flag to indicate if the use of password stdin is supported.
-    protected static boolean passwordStdinSupported;
+    static boolean passwordStdinSupported;
 
     @DataBoundConstructor
     public JfStep(Object args) {

--- a/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
@@ -143,17 +143,18 @@ public class JfStep extends Step {
          */
         public boolean isPasswordStdinSupported(FilePath workspace, EnvVars env, Launcher launcher, String jfrogBinaryPath) throws IOException, InterruptedException {
             TaskListener listener = getContext().get(TaskListener.class);
+            JenkinsBuildInfoLog buildInfoLog = new JenkinsBuildInfoLog(listener);
             boolean isPluginLauncher = launcher.getClass().getName().contains("org.jenkinsci.plugins");
             if (isPluginLauncher) {
-                listener.getLogger().println("Launcher is a plugin launcher. Password stdin is not supported.");
+                buildInfoLog.info("Launcher is a plugin launcher. Password stdin is not supported.");
                 return false;
             }
             Launcher.ProcStarter procStarter = launcher.launch().envs(env).pwd(workspace);
             Version currentCliVersion = getJfrogCliVersion(procStarter, jfrogBinaryPath);
             boolean supported = currentCliVersion.isAtLeast(MIN_CLI_VERSION_PASSWORD_STDIN);
 
-            listener.getLogger().println("JFrog CLI version: " + currentCliVersion);
-            listener.getLogger().println("Password stdin supported: " + supported);
+            buildInfoLog.info("JFrog CLI version: " + currentCliVersion);
+            buildInfoLog.info("Password stdin supported: " + supported);
 
             return supported;
         }

--- a/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
@@ -103,8 +103,7 @@ public class JfStep extends Step {
             EnvVars env = getContext().get(EnvVars.class);
             Run<?, ?> run = getContext().get(Run.class);
 
-            // Initialize values to be used across the class
-            initClassValues(workspace, env, launcher);
+            initStaticVariables(workspace, env, launcher);
 
             // Build the 'jf' command
             ArgumentListBuilder builder = new ArgumentListBuilder();
@@ -133,13 +132,13 @@ public class JfStep extends Step {
         }
 
         /**
-         * Initializes values required across the class for running CLI commands.
+         * Initializes static variables there are required during runtime.
          *
          * @param workspace Workspace to use for any file operations.
          * @param env       Environment variables for this step.
          * @param launcher  Launcher to start processes.
          */
-        private void initClassValues(FilePath workspace, EnvVars env, Launcher launcher) throws IOException, InterruptedException {
+        private void initStaticVariables(FilePath workspace, EnvVars env, Launcher launcher) throws IOException, InterruptedException {
             workspace.mkdirs();
             isWindows = !launcher.isUnix();
             jfrogBinaryPath = getJFrogCLIPath(env, isWindows);

--- a/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
@@ -97,6 +97,7 @@ public class JfStep extends Step {
             EnvVars env = getContext().get(EnvVars.class);
             Run<?, ?> run = getContext().get(Run.class);
 
+            workspace.mkdirs();
             boolean isWindows = !launcher.isUnix();
             String jfrogBinaryPath = getJFrogCLIPath(env, isWindows);
             boolean passwordStdinSupported = isPasswordStdinSupported(workspace, env, launcher, jfrogBinaryPath);
@@ -144,6 +145,7 @@ public class JfStep extends Step {
         public boolean isPasswordStdinSupported(FilePath workspace, EnvVars env, Launcher launcher, String jfrogBinaryPath) throws IOException, InterruptedException {
             TaskListener listener = getContext().get(TaskListener.class);
             JenkinsBuildInfoLog buildInfoLog = new JenkinsBuildInfoLog(listener);
+
             boolean isPluginLauncher = launcher.getClass().getName().contains("org.jenkinsci.plugins");
             if (isPluginLauncher) {
                 buildInfoLog.info("Launcher is a plugin launcher. Password stdin is not supported.");
@@ -160,7 +162,10 @@ public class JfStep extends Step {
         }
 
         static String getJFrogCLIPath(EnvVars env, boolean isWindows) {
+            // JFROG_BINARY_PATH is set according to the master OS. If not configured, the value of jfrogBinaryPath will
+            // eventually be 'jf' or 'jf.exe'. In that case, the JFrog CLI from the system path is used.
             String jfrogBinaryPath = Paths.get(env.get(JFROG_BINARY_PATH, ""), Utils.getJfrogCliBinaryName(isWindows)).toString();
+            // Modify jfrogBinaryPath according to the agent's OS
             return isWindows ?
                     FilenameUtils.separatorsToWindows(jfrogBinaryPath) :
                     FilenameUtils.separatorsToUnix(jfrogBinaryPath);

--- a/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
@@ -144,6 +144,7 @@ public class JfStep extends Step {
          * @param launcher  Launcher to start processes.
          */
         private void initClassValues(FilePath workspace, EnvVars env, Launcher launcher) throws IOException, InterruptedException {
+            workspace.mkdirs();
             isWindows = !launcher.isUnix();
             jfrogBinaryPath = getJFrogCLIPath(env, isWindows);
             passwordStdinSupported = isPasswordStdinSupported(workspace, env, launcher);

--- a/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
@@ -87,9 +87,7 @@ public class JfStep extends Step {
     }
 
     public static class Execution extends SynchronousNonBlockingStepExecution<String> {
-        private static final Version MIN_CLI_VERSION_PASSWORD_STDIN = new Version("2.31.1");
         private final String[] args;
-
 
         protected Execution(String[] args, @Nonnull StepContext context) {
             super(context);
@@ -154,8 +152,8 @@ public class JfStep extends Step {
          * 1. The JFrog CLI version on the agent (minimum supported version is 2.31.3).
          * 2. Whether the launcher is a custom (plugin) launcher.
          * <p>
-         * Note: Plugin-based launchers do not support stdin input handling by default
-         * and need special handling.
+         * Note: The primary reason for this limitation is that Docker plugin which is widely used
+         * does not support stdin input, because it is a custom launcher.
          *
          * @param workspace The workspace file path.
          * @param env       The environment variables.
@@ -309,9 +307,8 @@ public class JfStep extends Step {
         if (passwordStdinSupported) {
             // Use stdin
             builder.add("--password-stdin");
-            try (ByteArrayInputStream inputStream = new ByteArrayInputStream(credentials.getPassword().getPlainText().getBytes(StandardCharsets.UTF_8))) {
-                launcher.stdin(inputStream);
-            }
+            ByteArrayInputStream inputStream = new ByteArrayInputStream(credentials.getPassword().getPlainText().getBytes(StandardCharsets.UTF_8));
+            launcher.stdin(inputStream);
         } else {
             // Use masked default password argument
             builder.addMasked("--password=" + credentials.getPassword());

--- a/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
@@ -278,7 +278,7 @@ public class JfStep extends Step {
             }
         }
 
-        private void addConfigArguments(ArgumentListBuilder builder, JFrogPlatformInstance jfrogPlatformInstance, Job<?, ?> job, Launcher.ProcStarter launcher) throws IOException {
+        private void addConfigArguments(ArgumentListBuilder builder, JFrogPlatformInstance jfrogPlatformInstance, Job<?, ?> job, Launcher.ProcStarter launcher) {
             builder.add(jfrogBinaryPath).add("c").add("add").add(jfrogPlatformInstance.getId());
             addCredentialsArguments(builder, jfrogPlatformInstance, job, launcher);
             addUrlArguments(builder, jfrogPlatformInstance);
@@ -286,7 +286,7 @@ public class JfStep extends Step {
         }
     }
 
-    static void addCredentialsArguments(ArgumentListBuilder builder, JFrogPlatformInstance jfrogPlatformInstance, Job<?, ?> job, Launcher.ProcStarter launcher) throws IOException {
+    static void addCredentialsArguments(ArgumentListBuilder builder, JFrogPlatformInstance jfrogPlatformInstance, Job<?, ?> job, Launcher.ProcStarter launcher) {
         String credentialsId = jfrogPlatformInstance.getCredentialsConfig().getCredentialsId();
         StringCredentials accessTokenCredentials = PluginsUtils.accessTokenCredentialsLookup(credentialsId, job);
 
@@ -303,7 +303,7 @@ public class JfStep extends Step {
     // Stdin support requires a minimum CLI version and excludes plugin launchers.
     // Plugin launchers may lose stdin input, causing command failure;
     // hence, stdin is unsupported without plugin-specific handling.
-    static void addPasswordArgument(ArgumentListBuilder builder, Credentials credentials, Launcher.ProcStarter launcher) throws IOException {
+    static void addPasswordArgument(ArgumentListBuilder builder, Credentials credentials, Launcher.ProcStarter launcher) {
         if (passwordStdinSupported) {
             // Use stdin
             builder.add("--password-stdin");

--- a/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
@@ -57,6 +57,15 @@ public class JfStep extends Step {
         this.args = split(args.toString());
     }
 
+    /**
+     * Retrieves the version of the JFrog CLI.
+     *
+     * @param launcher        The process launcher used to execute the JFrog CLI command.
+     * @param jfrogBinaryPath The path to the JFrog CLI binary.
+     * @return The version of the JFrog CLI.
+     * @throws IOException          If an I/O error occurs while executing the command or reading the output.
+     * @throws InterruptedException If the process is interrupted while waiting for the command to complete.
+     */
     public static Version getJfrogCliVersion(Launcher.ProcStarter launcher, String jfrogBinaryPath) throws IOException, InterruptedException {
         try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
             ArgumentListBuilder builder = new ArgumentListBuilder();
@@ -304,7 +313,7 @@ public class JfStep extends Step {
      * @param launcher               The {@link Launcher.ProcStarter} used to execute the command.
      * @param passwordStdinSupported A boolean flag indicating whether the CLI supports password input via stdin.
      */
-     private static void addPasswordArgument(ArgumentListBuilder builder, Credentials credentials, Launcher.ProcStarter launcher, boolean passwordStdinSupported) {
+    private static void addPasswordArgument(ArgumentListBuilder builder, Credentials credentials, Launcher.ProcStarter launcher, boolean passwordStdinSupported) {
         if (passwordStdinSupported) {
             // Add argument to read password from stdin
             builder.add("--password-stdin");
@@ -322,6 +331,7 @@ public class JfStep extends Step {
         builder.add("--distribution-url=" + jfrogPlatformInstance.inferDistributionUrl());
         builder.add("--xray-url=" + jfrogPlatformInstance.inferXrayUrl());
     }
+
     /**
      * Add build-info Action if the command is 'jf rt bp' or 'jf rt build-publish'.
      *

--- a/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
@@ -226,17 +226,13 @@ public class JfStep extends Step {
 
             boolean isPluginLauncher = launcher.getClass().getName().contains("org.jenkinsci.plugins");
             if (isPluginLauncher) {
-                buildInfoLog.info("Launcher is a plugin launcher. Password stdin is not supported.");
+                buildInfoLog.debug("Password stdin is not supported,Launcher is a plugin launcher.");
                 return false;
             }
             Launcher.ProcStarter procStarter = launcher.launch().envs(env).pwd(workspace);
             Version currentCliVersion = getJfrogCliVersion(procStarter, jfrogBinaryPath);
-            boolean supported = currentCliVersion.isAtLeast(MIN_CLI_VERSION_PASSWORD_STDIN);
-
-            buildInfoLog.info("JFrog CLI version: " + currentCliVersion);
-            buildInfoLog.info("Password stdin supported: " + supported);
-
-            return supported;
+            buildInfoLog.debug("Password stdin is supported");
+            return currentCliVersion.isAtLeast(MIN_CLI_VERSION_PASSWORD_STDIN);
         }
 
         /**

--- a/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
@@ -47,7 +47,7 @@ public class JfStep extends Step {
     protected String[] args;
     static final Version MIN_CLI_VERSION_PASSWORD_STDIN = new Version("2.31.3");
     // The JFrog CLI binary path in the agent
-    static String jfrogBinaryPath;
+    private static String jfrogBinaryPath;
     // True if the agent's OS is windows
     static boolean isWindows;
     // Flag to indicate if the use of password stdin is supported.

--- a/src/test/java/io/jenkins/plugins/jfrog/JfStepTest.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/JfStepTest.java
@@ -1,16 +1,29 @@
 package io.jenkins.plugins.jfrog;
 
 import hudson.EnvVars;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.Job;
+import hudson.util.ArgumentListBuilder;
+import io.jenkins.plugins.jfrog.configuration.CredentialsConfig;
+import io.jenkins.plugins.jfrog.configuration.JFrogPlatformInstance;
+import org.jfrog.build.client.Version;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.stream.Stream;
 
 import static io.jenkins.plugins.jfrog.JfStep.Execution.getJFrogCLIPath;
+import static io.jenkins.plugins.jfrog.JfStep.MIN_CLI_VERSION_PASSWORD_STDIN;
 import static io.jenkins.plugins.jfrog.JfrogInstallation.JFROG_BINARY_PATH;
-
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 /**
  * @author yahavi
  **/
@@ -37,4 +50,91 @@ public class JfStepTest {
                 Arguments.of(new EnvVars(), true, "jf.exe")
         );
     }
+
+    @Test
+    void getJfrogCliVersionTest() throws IOException, InterruptedException {
+        // Mock the Launcher
+        Launcher launcher = mock(Launcher.class);
+        // Mock the Launcher.ProcStarter
+        Launcher.ProcStarter procStarter = mock(Launcher.ProcStarter.class);
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        // Mocks the return value of --version command
+        outputStream.write("jf version 2.31.0 ".getBytes());
+        // Mock the behavior of the Launcher and ProcStarter
+        when(launcher.launch()).thenReturn(procStarter);
+        when(procStarter.cmds(any(ArgumentListBuilder.class))).thenReturn(procStarter);
+        when(procStarter.pwd((FilePath) any())).thenReturn(procStarter);
+        when(procStarter.stdout(any(ByteArrayOutputStream.class))).thenAnswer(invocation -> {
+            ByteArrayOutputStream out = invocation.getArgument(0);
+            out.write(outputStream.toByteArray());
+            return procStarter;
+        });
+        when(procStarter.join()).thenReturn(0);
+
+        // Create an instance of JfStep and call the method
+        JfStep jfStep = new JfStep("--version");
+        JfStep.isWindows = System.getProperty("os.name").toLowerCase().contains("win");
+        Version version = jfStep.getJfrogCliVersion(procStarter);
+
+        // Verify the result
+        assertEquals("2.31.0", version.toString());
+    }
+
+    /**
+     * Tests the addCredentialsArguments method logic with password-stdin vs.-- password flag.
+     * Password-stdin flag should only be set if the CLI version is supported
+     * AND the launcher is not the plugin launcher.
+     * Plugin launchers do not support password-stdin, as they do not have access to the standard input by default.
+     *
+     * @param cliVersion       The CLI version
+     * @param isPluginLauncher Whether the launcher is the plugin launcher
+     * @param expectedOutput   The expected output
+     * @throws IOException error
+     */
+    @ParameterizedTest
+    @MethodSource("provideTestArguments")
+    void testAddCredentialsArguments(String cliVersion, boolean isPluginLauncher, String expectedOutput) throws IOException {
+        // Mock the necessary objects
+        JFrogPlatformInstance jfrogPlatformInstance = mock(JFrogPlatformInstance.class);
+        CredentialsConfig credentialsConfig = mock(CredentialsConfig.class);
+        when(jfrogPlatformInstance.getId()).thenReturn("instance-id");
+        when(jfrogPlatformInstance.getCredentialsConfig()).thenReturn(credentialsConfig);
+        when(credentialsConfig.getCredentialsId()).thenReturn("credentials-id");
+
+        Job<?, ?> job = mock(Job.class);
+        Launcher.ProcStarter launcher = mock(Launcher.ProcStarter.class);
+
+        // Create an instance of JfStep
+        JfStep jfStep = new JfStep("Mock Test");
+        // Mock password stdin supported or not.
+        JfStep.passwordStdinSupported = new Version(cliVersion).isAtLeast(MIN_CLI_VERSION_PASSWORD_STDIN) && !isPluginLauncher;
+
+        // Create an ArgumentListBuilder
+        ArgumentListBuilder builder = new ArgumentListBuilder();
+
+        // Call the addCredentialsArguments method
+        JfStep.addCredentialsArguments(builder, jfrogPlatformInstance, job, launcher);
+
+        // Verify the arguments
+        assertTrue(builder.toList().contains(expectedOutput));
+    }
+
+    private static Stream<Arguments> provideTestArguments() {
+        String passwordFlag = "--password=";
+        String passwordStdinFlag = "--password-stdin";
+        // Min version for password stdin is 2.31.3
+        return Stream.of(
+                // Supported CLI version but Plugin Launcher
+                Arguments.of("2.57.0", true, passwordFlag),
+                // Unsupported Version
+                Arguments.of("2.31.0", false, passwordFlag),
+                // Supported CLI version and local launcher
+                Arguments.of("2.57.0", false, passwordStdinFlag),
+                // Unsupported CLI version and Plugin Launcher
+                Arguments.of("2.31.0", true, passwordFlag),
+                // Minimum supported CLI version for password stdin
+                Arguments.of("2.31.3", false, passwordStdinFlag)
+        );
+    }
 }
+

--- a/src/test/java/io/jenkins/plugins/jfrog/JfStepTest.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/JfStepTest.java
@@ -86,7 +86,7 @@ public class JfStepTest {
      * Plugin launchers do not support password-stdin, as they do not have access to the standard input by default.
      *
      * @param cliVersion       The CLI version
-     * @param isPluginLauncher Whether the launcher is the plugin launcher
+     * @param isPluginLauncher Whether the launcher is a plugin launcher
      * @param expectedOutput   The expected output
      */
     @ParameterizedTest

--- a/src/test/java/io/jenkins/plugins/jfrog/JfStepTest.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/JfStepTest.java
@@ -72,8 +72,8 @@ public class JfStepTest {
         when(procStarter.join()).thenReturn(0);
 
         // Create an instance of JfStep and call the method
-        JfStep.isWindows = System.getProperty("os.name").toLowerCase().contains("win");
-        Version version = JfStep.getJfrogCliVersion(procStarter);
+        String jfrogBinaryPath = "path/to/jfrog";
+        Version version = JfStep.getJfrogCliVersion(procStarter, jfrogBinaryPath);
 
         // Verify the result
         assertEquals("2.31.0", version.toString());
@@ -102,14 +102,14 @@ public class JfStepTest {
         Job<?, ?> job = mock(Job.class);
         Launcher.ProcStarter launcher = mock(Launcher.ProcStarter.class);
 
-        // Mock password stdin supported or not.
-        JfStep.passwordStdinSupported = new Version(cliVersion).isAtLeast(MIN_CLI_VERSION_PASSWORD_STDIN) && !isPluginLauncher;
+        // Determine if password stdin is supported
+        boolean passwordStdinSupported = new Version(cliVersion).isAtLeast(MIN_CLI_VERSION_PASSWORD_STDIN) && !isPluginLauncher;
 
         // Create an ArgumentListBuilder
         ArgumentListBuilder builder = new ArgumentListBuilder();
 
         // Call the addCredentialsArguments method
-        JfStep.addCredentialsArguments(builder, jfrogPlatformInstance, job, launcher);
+        JfStep.addCredentialsArguments(builder, jfrogPlatformInstance, job, launcher, passwordStdinSupported);
 
         // Verify the arguments
         assertTrue(builder.toList().contains(expectedOutput));

--- a/src/test/java/io/jenkins/plugins/jfrog/JfStepTest.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/JfStepTest.java
@@ -72,9 +72,8 @@ public class JfStepTest {
         when(procStarter.join()).thenReturn(0);
 
         // Create an instance of JfStep and call the method
-        JfStep jfStep = new JfStep("--version");
         JfStep.isWindows = System.getProperty("os.name").toLowerCase().contains("win");
-        Version version = jfStep.getJfrogCliVersion(procStarter);
+        Version version = JfStep.getJfrogCliVersion(procStarter);
 
         // Verify the result
         assertEquals("2.31.0", version.toString());
@@ -89,11 +88,10 @@ public class JfStepTest {
      * @param cliVersion       The CLI version
      * @param isPluginLauncher Whether the launcher is the plugin launcher
      * @param expectedOutput   The expected output
-     * @throws IOException error
      */
     @ParameterizedTest
     @MethodSource("provideTestArguments")
-    void testAddCredentialsArguments(String cliVersion, boolean isPluginLauncher, String expectedOutput) throws IOException {
+    void testAddCredentialsArguments(String cliVersion, boolean isPluginLauncher, String expectedOutput) {
         // Mock the necessary objects
         JFrogPlatformInstance jfrogPlatformInstance = mock(JFrogPlatformInstance.class);
         CredentialsConfig credentialsConfig = mock(CredentialsConfig.class);
@@ -104,8 +102,6 @@ public class JfStepTest {
         Job<?, ?> job = mock(Job.class);
         Launcher.ProcStarter launcher = mock(Launcher.ProcStarter.class);
 
-        // Create an instance of JfStep
-        JfStep jfStep = new JfStep("Mock Test");
         // Mock password stdin supported or not.
         JfStep.passwordStdinSupported = new Version(cliVersion).isAtLeast(MIN_CLI_VERSION_PASSWORD_STDIN) && !isPluginLauncher;
 

--- a/src/test/java/io/jenkins/plugins/jfrog/integration/PipelineTestBase.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/integration/PipelineTestBase.java
@@ -165,7 +165,7 @@ public class PipelineTestBase {
             // Dummy server to test multiple configured servers.
             // The dummy server should be configured first to ensure the right server is being used (and not the first one).
             // platformCred cannot be empty since it is used to config the server.
-            add(new JFrogPlatformInstance("dummyServerId", "http://not-a-real-platform", platformCred, ARTIFACTORY_URL, "", ""));
+            add(new JFrogPlatformInstance("dummyServerId", "https://not-a-real-platform", platformCred, ARTIFACTORY_URL, "", ""));
             add(new JFrogPlatformInstance(TEST_CONFIGURED_SERVER_ID, PLATFORM_URL, platformCred, ARTIFACTORY_URL, "", ""));
         }};
         jfrogBuilder.setJfrogInstances(artifactoryServers);

--- a/src/test/java/io/jenkins/plugins/jfrog/integration/PipelineTestBase.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/integration/PipelineTestBase.java
@@ -68,7 +68,6 @@ public class PipelineTestBase {
     static final String JFROG_CLI_TOOL_NAME_1 = "jfrog-cli";
     static final String JFROG_CLI_TOOL_NAME_2 = "jfrog-cli-2";
     static final String TEST_CONFIGURED_SERVER_ID = "serverId";
-    static final String TEST_CONFIGURED_SERVER_ID2 = "serverId2";
 
     // Set up jenkins and configure latest JFrog CLI.
     public void initPipelineTest(JenkinsRule jenkins) throws Exception {
@@ -163,8 +162,11 @@ public class PipelineTestBase {
         Assert.assertNotNull(jfrogBuilder);
         CredentialsConfig platformCred = new CredentialsConfig(Secret.fromString(ARTIFACTORY_USERNAME), Secret.fromString(ARTIFACTORY_PASSWORD), Secret.fromString(ACCESS_TOKEN), "credentials");
         List<JFrogPlatformInstance> artifactoryServers = new ArrayList<>() {{
+            // Dummy server to test multiple configured servers.
+            // The dummy server should be configured first to ensure the right server is being used (and not the first one).
+            // platformCred cannot be empty since it is used to config the server.
+            add(new JFrogPlatformInstance("dummyServerId", "http://not-a-real-platform", platformCred, ARTIFACTORY_URL, "", ""));
             add(new JFrogPlatformInstance(TEST_CONFIGURED_SERVER_ID, PLATFORM_URL, platformCred, ARTIFACTORY_URL, "", ""));
-            add(new JFrogPlatformInstance(TEST_CONFIGURED_SERVER_ID2, PLATFORM_URL, platformCred, ARTIFACTORY_URL, "", ""));
         }};
         jfrogBuilder.setJfrogInstances(artifactoryServers);
         Jenkins.get().getDescriptorByType(JFrogPlatformBuilder.DescriptorImpl.class).setJfrogInstances(artifactoryServers);

--- a/src/test/java/io/jenkins/plugins/jfrog/integration/PipelineTestBase.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/integration/PipelineTestBase.java
@@ -19,7 +19,6 @@ import io.jenkins.plugins.jfrog.ArtifactoryInstaller;
 import io.jenkins.plugins.jfrog.BinaryInstaller;
 import io.jenkins.plugins.jfrog.JfrogInstallation;
 import io.jenkins.plugins.jfrog.ReleasesInstaller;
-import io.jenkins.plugins.jfrog.configuration.Credentials;
 import io.jenkins.plugins.jfrog.configuration.CredentialsConfig;
 import io.jenkins.plugins.jfrog.configuration.JFrogPlatformBuilder;
 import io.jenkins.plugins.jfrog.configuration.JFrogPlatformInstance;
@@ -161,12 +160,11 @@ public class PipelineTestBase {
     private void setGlobalConfiguration() throws IOException {
         JFrogPlatformBuilder.DescriptorImpl jfrogBuilder = (JFrogPlatformBuilder.DescriptorImpl) jenkins.getInstance().getDescriptor(JFrogPlatformBuilder.class);
         Assert.assertNotNull(jfrogBuilder);
-        CredentialsConfig emptyCred = new CredentialsConfig(StringUtils.EMPTY, Credentials.EMPTY_CREDENTIALS);
         CredentialsConfig platformCred = new CredentialsConfig(Secret.fromString(ARTIFACTORY_USERNAME), Secret.fromString(ARTIFACTORY_PASSWORD), Secret.fromString(ACCESS_TOKEN), "credentials");
-        List<JFrogPlatformInstance> artifactoryServers = new ArrayList<JFrogPlatformInstance>() {{
+        List<JFrogPlatformInstance> artifactoryServers = new ArrayList<>() {{
             // Dummy server to test multiple configured servers.
             // The dummy server should be configured first to ensure the right server is being used (and not the first one).
-            add(new JFrogPlatformInstance("dummyServerId", "", emptyCred, "", "", ""));
+            add(new JFrogPlatformInstance("dummyServerId", "", platformCred, "", "", ""));
             add(new JFrogPlatformInstance(TEST_CONFIGURED_SERVER_ID, PLATFORM_URL, platformCred, ARTIFACTORY_URL, "", ""));
         }};
         jfrogBuilder.setJfrogInstances(artifactoryServers);

--- a/src/test/java/io/jenkins/plugins/jfrog/integration/PipelineTestBase.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/integration/PipelineTestBase.java
@@ -68,6 +68,7 @@ public class PipelineTestBase {
     static final String JFROG_CLI_TOOL_NAME_1 = "jfrog-cli";
     static final String JFROG_CLI_TOOL_NAME_2 = "jfrog-cli-2";
     static final String TEST_CONFIGURED_SERVER_ID = "serverId";
+    static final String TEST_CONFIGURED_SERVER_ID2 = "serverId2";
 
     // Set up jenkins and configure latest JFrog CLI.
     public void initPipelineTest(JenkinsRule jenkins) throws Exception {
@@ -162,10 +163,8 @@ public class PipelineTestBase {
         Assert.assertNotNull(jfrogBuilder);
         CredentialsConfig platformCred = new CredentialsConfig(Secret.fromString(ARTIFACTORY_USERNAME), Secret.fromString(ARTIFACTORY_PASSWORD), Secret.fromString(ACCESS_TOKEN), "credentials");
         List<JFrogPlatformInstance> artifactoryServers = new ArrayList<>() {{
-            // Dummy server to test multiple configured servers.
-            // The dummy server should be configured first to ensure the right server is being used (and not the first one).
-            add(new JFrogPlatformInstance("dummyServerId", "", platformCred, "", "", ""));
             add(new JFrogPlatformInstance(TEST_CONFIGURED_SERVER_ID, PLATFORM_URL, platformCred, ARTIFACTORY_URL, "", ""));
+            add(new JFrogPlatformInstance(TEST_CONFIGURED_SERVER_ID2, PLATFORM_URL, platformCred, ARTIFACTORY_URL, "", ""));
         }};
         jfrogBuilder.setJfrogInstances(artifactoryServers);
         Jenkins.get().getDescriptorByType(JFrogPlatformBuilder.DescriptorImpl.class).setJfrogInstances(artifactoryServers);


### PR DESCRIPTION
- [x] This pull request is created in the [jfrog/jenkins-jfrog-plugin](https://github.com/jfrog/jenkins-jfrog-plugin) repository.

Utilise the --password-stdin flag if supported CLI version is being used.

**When is it possible?**
1. CLI version supported.
2. No custom launcher is used.

When a custom launcher is being used, the stdin we prepare in the plugin does not gets passed to the custom launchers, for example docker launchers. 
