### PR TITLE
Fix to read password std input from environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,17 @@ environment {
 }
 ```
 
+### Setting the password via standard input
+
+The plugin by default sets the password standard input as false. If you wish to change the default value, add the
+following code to your pipeline script: this adds flag as --password-stdin to the JFrog CLI commands.
+
+```groovy
+environment {
+    JFROG_CLI_PASSWORD_STDIN_SUPPORT = "true"
+}
+```
+
 ### Using multiple JFrog Platform instances
 
 If you have multiple JFrog Platform instances configured, you can use the `–-server-id` command option with

--- a/README.md
+++ b/README.md
@@ -153,11 +153,11 @@ environment {
 
 ### Setting the password via standard input
 
-The plugin by default sets the password standard input as false. If you wish to change the default value, add the
-following code to your pipeline script: this adds flag as --password-stdin to the JFrog CLI commands.
-The primary reason for this environment variable is few plugins does not support stdin input, because it is a custom launcher.
-When a custom launcher is being used, the stdin we prepare in the plugin does not get passed to the custom launchers,
-for example docker launchers.
+The plugin by default tries to detect and set the password standard input. If you wish to change the default behaviour, 
+add the following environment variable to your pipeline script: this adds flag as --password-stdin to the JFrog CLI 
+commands. The primary reason for this environment variable is few plugins does not support stdin input, because it is 
+a custom launcher. When a custom launcher is being used, the stdin we prepare in the plugin does not get passed to the
+custom launchers, for example docker launchers.
 
 ```groovy
 environment {

--- a/README.md
+++ b/README.md
@@ -155,6 +155,10 @@ environment {
 
 The plugin by default sets the password standard input as false. If you wish to change the default value, add the
 following code to your pipeline script: this adds flag as --password-stdin to the JFrog CLI commands.
+The primary reason for this config is few plugins does not support stdin input, because it is a custom launcher.
+When a custom launcher is being used, the stdin we prepare in the plugin does not get passed to the custom launchers,
+for example docker launchers. `JFROG_CLI_PASSWORD_STDIN_SUPPORT` environment variable is used to overcome this issue set
+it to true to use the password as stdin which adds `--password-stdin` flag.
 
 ```groovy
 environment {

--- a/README.md
+++ b/README.md
@@ -155,10 +155,9 @@ environment {
 
 The plugin by default sets the password standard input as false. If you wish to change the default value, add the
 following code to your pipeline script: this adds flag as --password-stdin to the JFrog CLI commands.
-The primary reason for this config is few plugins does not support stdin input, because it is a custom launcher.
+The primary reason for this environment variable is few plugins does not support stdin input, because it is a custom launcher.
 When a custom launcher is being used, the stdin we prepare in the plugin does not get passed to the custom launchers,
-for example docker launchers. `JFROG_CLI_PASSWORD_STDIN_SUPPORT` environment variable is used to overcome this issue set
-it to true to use the password as stdin which adds `--password-stdin` flag.
+for example docker launchers.
 
 ```groovy
 environment {

--- a/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
@@ -111,7 +111,7 @@ public class JfStep extends Step {
             ArgumentListBuilder builder = new ArgumentListBuilder();
             boolean isWindows = !launcher.isUnix();
             String jfrogBinaryPath = getJFrogCLIPath(env, isWindows);
-            boolean passwordStdinSupported = isPasswordInputViaStdinSupported(env);
+            boolean passwordStdinSupported = isPasswordInputViaStdinSupported(workspace, env, launcher, jfrogBinaryPath);
 
             builder.add(jfrogBinaryPath).add(args);
             if (isWindows) {
@@ -217,8 +217,11 @@ public class JfStep extends Step {
          * @param environmentVariables The environment variables.
          * @return true if stdin-based password handling is supported; false otherwise.
          */
-        public boolean isPasswordInputViaStdinSupported(EnvVars environmentVariables) {
+        public boolean isPasswordInputViaStdinSupported(FilePath workspace, EnvVars environmentVariables, Launcher launcher, String jfrogBinaryPath) throws IOException, InterruptedException {
+            TaskListener listener = getContext().get(TaskListener.class);
+            JenkinsBuildInfoLog buildInfoLog = new JenkinsBuildInfoLog(listener);
             boolean isSupported = Boolean.parseBoolean(environmentVariables.get("JFROG_CLI_PASSWORD_STDIN_SUPPORT", "false"));
+            Launcher.ProcStarter procStarter = launcher.launch().envs(environmentVariables).pwd(workspace);
             Version currentCliVersion = getJfrogCliVersion(procStarter, jfrogBinaryPath);
             boolean isMinimumCLIVersionPasswdSTDIN = currentCliVersion.isAtLeast(MIN_CLI_VERSION_PASSWORD_STDIN);
             if (isMinimumCLIVersionPasswdSTDIN && isSupported) {

--- a/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
@@ -236,14 +236,11 @@ public class JfStep extends Step {
                 buildInfoLog.debug("Password stdin is supported");
                 return isMinimumCLIVersionPasswdSTDIN;
             }
-            boolean isSupported = Boolean.parseBoolean(readJFrogCliPwdStdinSupport);
-            if (!isMinimumCLIVersionPasswdSTDIN && isSupported) {
-                buildInfoLog.error("Password input via stdin is not supported, JFrog CLI version is below the minimum required version.");
-            } else if (isMinimumCLIVersionPasswdSTDIN && isSupported) {
-                return true;
-            }
-            buildInfoLog.debug("Password input via stdin is not supported, Launcher is a plugin launcher.");
-            return false;
+    boolean isSupported = Boolean.parseBoolean(readJFrogCliPwdStdinSupport);
+    if (isSupported && !isMinimumCLIVersionPasswdSTDIN) {
+        buildInfoLog.error("Password input via stdin is not supported, JFrog CLI version is below the minimum required version.");
+    }
+    return isSupported && isMinimumCLIVersionPasswdSTDIN;
         }
 
         /**

--- a/src/test/java/io/jenkins/plugins/jfrog/JfStepTest.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/JfStepTest.java
@@ -91,7 +91,7 @@ public class JfStepTest {
      */
     @ParameterizedTest
     @MethodSource("provideTestArguments")
-    void testAddCredentialsArguments(String cliVersion, boolean isPluginLauncher, String expectedOutput) {
+    void testAddCredentialsArguments(String cliVersion, EnvVars envVars, String expectedOutput) {
         // Mock the necessary objects
         JFrogPlatformInstance jfrogPlatformInstance = mock(JFrogPlatformInstance.class);
         CredentialsConfig credentialsConfig = mock(CredentialsConfig.class);
@@ -103,7 +103,7 @@ public class JfStepTest {
         Launcher.ProcStarter launcher = mock(Launcher.ProcStarter.class);
 
         // Determine if password stdin is supported
-        boolean passwordStdinSupported = new Version(cliVersion).isAtLeast(MIN_CLI_VERSION_PASSWORD_STDIN) && !isPluginLauncher;
+        boolean passwordStdinSupported = new Version(cliVersion).isAtLeast(MIN_CLI_VERSION_PASSWORD_STDIN) && envVars.get("JFROG_CLI_PASSWORD_STDIN_SUPPORT", "false").equals("true");
 
         // Create an ArgumentListBuilder
         ArgumentListBuilder builder = new ArgumentListBuilder();
@@ -118,25 +118,29 @@ public class JfStepTest {
     private static Stream<Arguments> provideTestArguments() {
         String passwordFlag = "--password=";
         String passwordStdinFlag = "--password-stdin";
+        EnvVars envVarsTrue = mock(EnvVars.class);
+        when(envVarsTrue.get("JFROG_CLI_PASSWORD_STDIN_SUPPORT", "false")).thenReturn("true");
+        EnvVars envVarsFalse = mock(EnvVars.class);
+        when(envVarsFalse.get("JFROG_CLI_PASSWORD_STDIN_SUPPORT", "false")).thenReturn("false");
         // Min version for password stdin is 2.31.3
         return Stream.of(
                 // Supported CLI version but Plugin Launcher
-                Arguments.of("2.57.0", true, passwordFlag),
-                // Unsupported Version
-                Arguments.of("2.31.0", false, passwordFlag),
-                // Supported CLI version and local launcher
-                Arguments.of("2.57.0", false, passwordStdinFlag),
+                Arguments.of("2.57.0", envVarsTrue, passwordFlag),
                 // Unsupported CLI version and Plugin Launcher
-                Arguments.of("2.31.0", true, passwordFlag),
+                Arguments.of("2.31.0", envVarsTrue, passwordFlag),
+                // Unsupported Version
+                Arguments.of("2.31.0", envVarsFalse, passwordFlag),
+                // Supported CLI version and local launcher
+                Arguments.of("2.57.0", envVarsFalse, passwordStdinFlag),
                 // Minimum supported CLI version for password stdin
-                Arguments.of("2.31.3", false, passwordStdinFlag)
+                Arguments.of("2.31.3", envVarsFalse, passwordStdinFlag)
         );
     }
 
     @Test
     void testIsPasswordInputViaStdinSupported_True() {
         EnvVars envVars = mock(EnvVars.class);
-        when(envVars.get("JFROG_CLI_PASSWORD_STDIN_SUPPORTED", "false")).thenReturn("true");
+        when(envVars.get("JFROG_CLI_PASSWORD_STDIN_SUPPORT", "false")).thenReturn("true");
         JfStep.Execution execution = mock(JfStep.Execution.class, Mockito.CALLS_REAL_METHODS);
         assertTrue(execution.isPasswordInputViaStdinSupported(envVars));
     }
@@ -144,7 +148,7 @@ public class JfStepTest {
     @Test
     void testIsPasswordInputViaStdinSupported_False() {
         EnvVars envVars = mock(EnvVars.class);
-        when(envVars.get("JFROG_CLI_PASSWORD_STDIN_SUPPORTED", "false")).thenReturn("false");
+        when(envVars.get("JFROG_CLI_PASSWORD_STDIN_SUPPORT", "false")).thenReturn("false");
         JfStep.Execution execution = mock(JfStep.Execution.class, Mockito.CALLS_REAL_METHODS);
         assertFalse(execution.isPasswordInputViaStdinSupported(envVars));
     }

--- a/src/test/java/io/jenkins/plugins/jfrog/JfStepTest.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/JfStepTest.java
@@ -125,32 +125,18 @@ public class JfStepTest {
         // Min version for password stdin is 2.31.3
         return Stream.of(
                 // Supported CLI version but Plugin Launcher
-                Arguments.of("2.57.0", envVarsTrue, passwordFlag),
+                Arguments.of("2.57.0", envVarsTrue, passwordStdinFlag),
                 // Unsupported CLI version and Plugin Launcher
                 Arguments.of("2.31.0", envVarsTrue, passwordFlag),
                 // Unsupported Version
                 Arguments.of("2.31.0", envVarsFalse, passwordFlag),
                 // Supported CLI version and local launcher
-                Arguments.of("2.57.0", envVarsFalse, passwordStdinFlag),
+                Arguments.of("2.57.0", envVarsFalse, passwordFlag),
                 // Minimum supported CLI version for password stdin
-                Arguments.of("2.31.3", envVarsFalse, passwordStdinFlag)
+                Arguments.of("2.31.3", envVarsFalse, passwordFlag),
+                // Minimum supported CLI version for password stdin
+                Arguments.of("2.31.3", envVarsTrue, passwordStdinFlag)
         );
-    }
-
-    @Test
-    void testIsPasswordInputViaStdinSupported_True() {
-        EnvVars envVars = mock(EnvVars.class);
-        when(envVars.get("JFROG_CLI_PASSWORD_STDIN_SUPPORT", "false")).thenReturn("true");
-        JfStep.Execution execution = mock(JfStep.Execution.class, Mockito.CALLS_REAL_METHODS);
-        assertTrue(execution.isPasswordInputViaStdinSupported(envVars));
-    }
-
-    @Test
-    void testIsPasswordInputViaStdinSupported_False() {
-        EnvVars envVars = mock(EnvVars.class);
-        when(envVars.get("JFROG_CLI_PASSWORD_STDIN_SUPPORT", "false")).thenReturn("false");
-        JfStep.Execution execution = mock(JfStep.Execution.class, Mockito.CALLS_REAL_METHODS);
-        assertFalse(execution.isPasswordInputViaStdinSupported(envVars));
     }
 }
 

--- a/src/test/java/io/jenkins/plugins/jfrog/JfStepTest.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/JfStepTest.java
@@ -135,27 +135,17 @@ public class JfStepTest {
 
     @Test
     void testIsPasswordInputViaStdinSupported_True() {
-        // Mock the environment variables
         EnvVars envVars = mock(EnvVars.class);
         when(envVars.get("JFROG_CLI_PASSWORD_STDIN_SUPPORTED", "false")).thenReturn("true");
-
-        // Create an instance of JfStep.Execution
         JfStep.Execution execution = mock(JfStep.Execution.class, Mockito.CALLS_REAL_METHODS);
-
-        // Call the method and assert the result
         assertTrue(execution.isPasswordInputViaStdinSupported(envVars));
     }
 
     @Test
     void testIsPasswordInputViaStdinSupported_False() {
-        // Mock the environment variables
         EnvVars envVars = mock(EnvVars.class);
         when(envVars.get("JFROG_CLI_PASSWORD_STDIN_SUPPORTED", "false")).thenReturn("false");
-
-        // Create an instance of JfStep.Execution
         JfStep.Execution execution = mock(JfStep.Execution.class, Mockito.CALLS_REAL_METHODS);
-
-        // Call the method and assert the result
         assertFalse(execution.isPasswordInputViaStdinSupported(envVars));
     }
 }

--- a/src/test/java/io/jenkins/plugins/jfrog/JfStepTest.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/JfStepTest.java
@@ -132,5 +132,31 @@ public class JfStepTest {
                 Arguments.of("2.31.3", false, passwordStdinFlag)
         );
     }
+
+    @Test
+    void testIsPasswordInputViaStdinSupported_True() {
+        // Mock the environment variables
+        EnvVars envVars = mock(EnvVars.class);
+        when(envVars.get("JFROG_CLI_PASSWORD_STDIN_SUPPORTED", "false")).thenReturn("true");
+
+        // Create an instance of JfStep.Execution
+        JfStep.Execution execution = mock(JfStep.Execution.class, Mockito.CALLS_REAL_METHODS);
+
+        // Call the method and assert the result
+        assertTrue(execution.isPasswordInputViaStdinSupported(envVars));
+    }
+
+    @Test
+    void testIsPasswordInputViaStdinSupported_False() {
+        // Mock the environment variables
+        EnvVars envVars = mock(EnvVars.class);
+        when(envVars.get("JFROG_CLI_PASSWORD_STDIN_SUPPORTED", "false")).thenReturn("false");
+
+        // Create an instance of JfStep.Execution
+        JfStep.Execution execution = mock(JfStep.Execution.class, Mockito.CALLS_REAL_METHODS);
+
+        // Call the method and assert the result
+        assertFalse(execution.isPasswordInputViaStdinSupported(envVars));
+    }
 }
 


### PR DESCRIPTION
- [x] This pull request is created in the [jfrog/jenkins-jfrog-plugin](https://github.com/jfrog/jenkins-jfrog-plugin) repository.


---

### **Fix: Improve Handling of Password via Stdin with Opt-in Mechanism**

#### **Background**
We initially identified a security concern where the `--password` flag was being passed in the CLI, potentially exposing credentials. To mitigate this risk, we moved password input to be passed via stdin instead ([#101](https://github.com/jfrog/jenkins-jfrog-plugin/pull/101))

However, this change introduced an issue: custom launchers required specific implementations to support passing values via stdin, which led to failures in certain cases. We attempted to address this by handling custom plugins separately (https://github.com/jfrog/jenkins-jfrog-plugin/pull/114), but later discovered that Kubernetes-related plugins were also affected.

#### **Final Resolution**
To ensure better compatibility across different environments while maintaining security improvements, this PR introduces an **opt-in mechanism** for passing passwords via stdin. Now, users who wish to use this feature can explicitly enable it by setting an environment variable.

#### **Changes in This PR**
- Introduced an environment variable (`JFROG_CLI_PASSWORD_STDIN_SUPPORT`) to control whether passwords are passed via stdin.
- By default, authentication will fall back to the original method unless explicitly enabled.
- Ensures compatibility with various Jenkins launchers, including Kubernetes plugins.
- Maintains security best practices while avoiding breaking existing workflows.

#### **Impact**
- **Users who rely on stdin authentication** must now set the environment variable to continue using it.
- **Default behavior remains unchanged**, preventing unexpected failures in custom launchers and Kubernetes setups.

#### **Related PRs**
- [[#101](https://github.com/jfrog/jenkins-jfrog-plugin/pull/101)](https://github.com/jfrog/jenkins-jfrog-plugin/pull/101) - Initial stdin password handling  
- [[#114](https://github.com/jfrog/jenkins-jfrog-plugin/pull/114)](https://github.com/jfrog/jenkins-jfrog-plugin/pull/114) - Fix for custom launchers  

This PR ensures a balance between security and compatibility, allowing users to opt into stdin-based authentication when applicable.
