### PR TITLE
Added logic for storing encryption file path only

### DIFF
--- a/src/main/java/io/jenkins/plugins/jfrog/CliEnvConfigurator.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/CliEnvConfigurator.java
@@ -44,7 +44,7 @@ public class CliEnvConfigurator {
         }
         if (encryptionKey.shouldEncrypt()) {
             // Set up a random encryption key to make sure no raw text secrets are stored in the file system
-            env.putIfAbsent(JFROG_CLI_ENCRYPTION_KEY, encryptionKey.getKey());
+            env.putIfAbsent(JFROG_CLI_ENCRYPTION_KEY, encryptionKey.getKeyOrFilePath());
         }
     }
 

--- a/src/main/java/io/jenkins/plugins/jfrog/actions/JFrogCliConfigEncryption.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/actions/JFrogCliConfigEncryption.java
@@ -57,6 +57,13 @@ public class JFrogCliConfigEncryption implements Action {
         }
     }
 
+    public String getKeyOrFilePath() {
+        if (this.keyOrPath == null || this.keyOrPath.isEmpty()) {
+            return null;
+        }
+        return this.keyOrPath;
+    }
+
     public boolean shouldEncrypt() {
         return shouldEncrypt;
     }

--- a/src/test/java/io/jenkins/plugins/jfrog/CliEnvConfiguratorTest.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/CliEnvConfiguratorTest.java
@@ -46,7 +46,7 @@ public class CliEnvConfiguratorTest {
         assertEquals(32, configEncryption.getKey().length());
 
         invokeConfigureCliEnv("a/b/c", configEncryption);
-        assertEnv(envVars, JFROG_CLI_ENCRYPTION_KEY, configEncryption.getKey());
+        assertEnv(envVars, JFROG_CLI_ENCRYPTION_KEY, configEncryption.getKeyOrFilePath());
     }
 
     @Test


### PR DESCRIPTION
- [x] This pull request is created in the [jfrog/jenkins-jfrog-plugin](https://github.com/jfrog/jenkins-jfrog-plugin) repository.

Description: Updated test cases where Key is expected we are storing filepath only.