### PR TITLE
Updated encryption key file path to jfrog-home dir instead of jenkins…

### DIFF
--- a/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
@@ -196,7 +196,7 @@ public class JfStep extends Step {
                 run.addAction(jfrogCliConfigEncryption);
             }
             FilePath jfrogHomeTempDir = Utils.createAndGetJfrogCliHomeTempDir(workspace, String.valueOf(run.getNumber()));
-            CliEnvConfigurator.configureCliEnv(env, jfrogHomeTempDir.getRemote(), jfrogCliConfigEncryption);
+            CliEnvConfigurator.configureCliEnv(env, jfrogHomeTempDir, jfrogCliConfigEncryption);
             Launcher.ProcStarter jfLauncher = launcher.launch().envs(env).pwd(workspace).stdout(listener);
             // Configure all servers, skip if all server ids have already been configured.
             if (shouldConfig(jfrogHomeTempDir)) {

--- a/src/main/java/io/jenkins/plugins/jfrog/JfrogBuilder.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfrogBuilder.java
@@ -247,7 +247,7 @@ public class JfrogBuilder extends Builder {
         }
 
         FilePath jfrogHomeTempDir = Utils.createAndGetJfrogCliHomeTempDir(workspace, String.valueOf(run.getNumber()));
-        CliEnvConfigurator.configureCliEnv(env, jfrogHomeTempDir.getRemote(), jfrogCliConfigEncryption);
+        CliEnvConfigurator.configureCliEnv(env, jfrogHomeTempDir, jfrogCliConfigEncryption);
         Launcher.ProcStarter jfLauncher = launcher.launch().envs(env).pwd(workspace).stdout(cliOutputListener);
 
         // Configure all servers, skip if all server ids have already been configured.

--- a/src/main/java/io/jenkins/plugins/jfrog/actions/JFrogCliConfigEncryption.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/actions/JFrogCliConfigEncryption.java
@@ -1,13 +1,11 @@
 package io.jenkins.plugins.jfrog.actions;
 
 import hudson.EnvVars;
+import hudson.FilePath;
 import hudson.model.Action;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.UUID;
 
 import static io.jenkins.plugins.jfrog.CliEnvConfigurator.JFROG_CLI_HOME_DIR;
@@ -36,14 +34,15 @@ public class JFrogCliConfigEncryption implements Action {
     }
 
     /**
-     * Writes the encryption key to a file in the specified directory.
-     * This should be called with the jfrogHomeTempDir path which is accessible inside Docker containers.
+     * Writes the encryption key to a file in the specified directory on the agent.
+     * Uses FilePath to ensure the file is written on the remote agent, not the controller.
      *
-     * @param jfrogHomeTempDir - The JFrog CLI home temp directory path (accessible from agent/Docker)
-     * @return The path to the key file
+     * @param jfrogHomeTempDir - The JFrog CLI home temp directory (FilePath on the agent)
+     * @return The path to the key file (as seen by the agent)
      * @throws IOException if the file cannot be written
+     * @throws InterruptedException if the operation is interrupted
      */
-    public String writeKeyFile(String jfrogHomeTempDir) throws IOException {
+    public String writeKeyFile(FilePath jfrogHomeTempDir) throws IOException, InterruptedException {
         if (this.key == null || this.key.isEmpty()) {
             return null;
         }
@@ -51,12 +50,14 @@ public class JFrogCliConfigEncryption implements Action {
         if (this.keyFilePath != null) {
             return this.keyFilePath;
         }
-        Path encryptionDir = Paths.get(jfrogHomeTempDir, "encryption");
-        Files.createDirectories(encryptionDir);
+        // Use FilePath operations to write on the agent (not controller)
+        FilePath encryptionDir = jfrogHomeTempDir.child("encryption");
+        encryptionDir.mkdirs();
         String fileName = UUID.randomUUID().toString() + ".key";
-        Path keyPath = encryptionDir.resolve(fileName);
-        Files.write(keyPath, this.key.getBytes(StandardCharsets.UTF_8));
-        this.keyFilePath = keyPath.toString();
+        FilePath keyFile = encryptionDir.child(fileName);
+        keyFile.write(this.key, StandardCharsets.UTF_8.name());
+        // getRemote() returns the path as seen by the agent
+        this.keyFilePath = keyFile.getRemote();
         return this.keyFilePath;
     }
 

--- a/src/test/java/io/jenkins/plugins/jfrog/CliEnvConfiguratorProxyTest.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/CliEnvConfiguratorProxyTest.java
@@ -24,7 +24,7 @@ public class CliEnvConfiguratorProxyTest extends CliEnvConfiguratorTest {
     }
 
     @Test
-    public void configureCliEnvHttpProxyTest() throws IOException {
+    public void configureCliEnvHttpProxyTest() throws IOException, InterruptedException {
         proxyConfiguration.port = 80;
         invokeConfigureCliEnv();
         assertEnv(envVars, HTTP_PROXY_ENV, "http://acme.proxy.io:80");
@@ -33,7 +33,7 @@ public class CliEnvConfiguratorProxyTest extends CliEnvConfiguratorTest {
     }
 
     @Test
-    public void configureCliEnvHttpsProxyTest() throws IOException {
+    public void configureCliEnvHttpsProxyTest() throws IOException, InterruptedException {
         proxyConfiguration.port = 443;
         invokeConfigureCliEnv();
         assertEnv(envVars, HTTP_PROXY_ENV, "https://acme.proxy.io:443");
@@ -42,7 +42,7 @@ public class CliEnvConfiguratorProxyTest extends CliEnvConfiguratorTest {
     }
 
     @Test
-    public void configureCliEnvHttpProxyAuthTest() throws IOException {
+    public void configureCliEnvHttpProxyAuthTest() throws IOException, InterruptedException {
         proxyConfiguration.port = 80;
         proxyConfiguration.username = "andor";
         proxyConfiguration.password = "RogueOne";
@@ -53,7 +53,7 @@ public class CliEnvConfiguratorProxyTest extends CliEnvConfiguratorTest {
     }
 
     @Test
-    public void configureCliEnvHttpsProxyAuthTest() throws IOException {
+    public void configureCliEnvHttpsProxyAuthTest() throws IOException, InterruptedException {
         proxyConfiguration.port = 443;
         proxyConfiguration.username = "andor";
         proxyConfiguration.password = "RogueOne";
@@ -64,14 +64,14 @@ public class CliEnvConfiguratorProxyTest extends CliEnvConfiguratorTest {
     }
 
     @Test
-    public void configureCliEnvNoOverrideHttpTest() throws IOException {
+    public void configureCliEnvNoOverrideHttpTest() throws IOException, InterruptedException {
         envVars.put(HTTP_PROXY_ENV, "http://acme2.proxy.io:777");
         invokeConfigureCliEnv();
         assertEnv(envVars, HTTP_PROXY_ENV, "http://acme2.proxy.io:777");
     }
 
     @Test
-    public void configureCliEnvNoOverrideTest() throws IOException {
+    public void configureCliEnvNoOverrideTest() throws IOException, InterruptedException {
         envVars.put(HTTP_PROXY_ENV, "http://acme2.proxy.io:80");
         envVars.put(HTTPS_PROXY_ENV, "http://acme2.proxy.io:443");
         invokeConfigureCliEnv();


### PR DESCRIPTION
- [x] This pull request is created in the [jfrog/jenkins-jfrog-plugin](https://github.com/jfrog/jenkins-jfrog-plugin) repository.

## Description:
What is the change? 
Store encrypted key in a file under JfrogHomeDir

Why is this fix?
encrypted key file was stored in Jenkins Workspace which is not accessible and failing with `failed to stat encryption key file`