### PR TITLE
Fix/rteco 900 jfrog jenkins plugin latest version is not working in multi agent pipeline

### DIFF
--- a/src/main/java/io/jenkins/plugins/jfrog/CliEnvConfigurator.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/CliEnvConfigurator.java
@@ -49,10 +49,11 @@ public class CliEnvConfigurator {
             setupProxy(env);
         }
         if (encryptionKey.shouldEncrypt()) {
-            // Write the encryption key file on the agent (not controller) using FilePath.
-            // This ensures the file exists where the JFrog CLI runs (Docker/remote agent).
+            // Write the encryption key file on the current agent using FilePath.
+            // Always overwrite (not putIfAbsent) because in multi-agent pipelines the env
+            // var may still hold the previous agent's path, which doesn't exist on this agent.
             String keyFilePath = encryptionKey.writeKeyFile(jfrogHomeTempDir);
-            env.putIfAbsent(JFROG_CLI_ENCRYPTION_KEY, keyFilePath);
+            env.put(JFROG_CLI_ENCRYPTION_KEY, keyFilePath);
         }
     }
 


### PR DESCRIPTION
- [x] This pull request is created in the [jfrog/jenkins-jfrog-plugin](https://github.com/jfrog/jenkins-jfrog-plugin) repository.
What: Updated the JFROG_CLI_ENCRYPTION_KEY's file path in current agent space
Why: One agent can't access the another's agent filepath, due to which encryption key file path is not accessible.