### PR TITLE
Fix security audit violation - upgrade build-info-extractor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <jenkins.version>2.462.3</jenkins.version>
         <skipITs>true</skipITs>
-        <buildinfo.version>2.41.23</buildinfo.version>
+        <buildinfo.version>2.43.6</buildinfo.version>
     </properties>
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>jfrog</artifactId>
@@ -122,6 +122,11 @@
                     <groupId>org.apache.commons</groupId>
                     <artifactId>commons-compress</artifactId>
                 </exclusion>
+                <!-- Provided by commons-lang3-api plugin -->
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -129,6 +134,19 @@
             <artifactId>build-info-api</artifactId>
             <version>${buildinfo.version}</version>
             <exclusions>
+                <!-- Provided by jackson2-api plugin -->
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
                 <!-- Provided by Jenkins core -->
                 <exclusion>
                     <groupId>com.google.guava</groupId>
@@ -149,6 +167,11 @@
                 <exclusion>
                     <groupId>org.apache.commons</groupId>
                     <artifactId>commons-compress</artifactId>
+                </exclusion>
+                <!-- Provided by commons-lang3-api plugin -->
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
                 </exclusion>
                 <!-- Provided by apache-httpcomponents-client-4-api plugin -->
                 <exclusion>
@@ -162,6 +185,19 @@
             <artifactId>build-info-client</artifactId>
             <version>${buildinfo.version}</version>
             <exclusions>
+                <!-- Provided by jackson2-api plugin -->
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
                 <!-- Provided by Jenkins core -->
                 <exclusion>
                     <groupId>com.google.guava</groupId>
@@ -183,12 +219,37 @@
                     <groupId>org.apache.commons</groupId>
                     <artifactId>commons-compress</artifactId>
                 </exclusion>
+                <!-- Provided by commons-lang3-api plugin -->
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jfrog.filespecs</groupId>
             <artifactId>file-specs-java</artifactId>
             <version>1.1.2</version>
+            <exclusions>
+                <!-- Provided by jackson2-api plugin -->
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <!-- Provided by commons-lang3-api plugin -->
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jfrog.artifactory.client</groupId>


### PR DESCRIPTION
- [ ] This pull request is created in the [jfrog/jenkins-jfrog-plugin](https://github.com/jfrog/jenkins-jfrog-plugin) repository.
---
Upgrade build-info-extractor: 2.41.23 → 2.43.6 to resolve jf audit security violations in direct dependencies.
