### PR TITLE
RTECO-1006 - Optimize CLI installation: per-pipeline cache, cross-platform OS detection, stale sha256 cleanup

### DIFF
--- a/e2e/local/docker-compose-agents.yml
+++ b/e2e/local/docker-compose-agents.yml
@@ -1,0 +1,24 @@
+services:
+  agent-linux-amd64:
+    image: jenkins/inbound-agent:latest
+    platform: linux/amd64
+    container_name: jenkins-agent-amd64
+    environment:
+      JENKINS_URL: http://host.docker.internal:8080
+      JENKINS_AGENT_NAME: agent-linux-amd64
+      JENKINS_SECRET: ${AGENT_AMD64_SECRET}
+      JENKINS_AGENT_WORKDIR: /home/jenkins/agent
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  agent-linux-arm64:
+    image: jenkins/inbound-agent:latest
+    platform: linux/arm64
+    container_name: jenkins-agent-arm64
+    environment:
+      JENKINS_URL: http://host.docker.internal:8080
+      JENKINS_AGENT_NAME: agent-linux-arm64
+      JENKINS_SECRET: ${AGENT_ARM64_SECRET}
+      JENKINS_AGENT_WORKDIR: /home/jenkins/agent
+    extra_hosts:
+      - "host.docker.internal:host-gateway"

--- a/e2e/local/setup-agents.sh
+++ b/e2e/local/setup-agents.sh
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+# Usage: source e2e/setup-agents.sh
+#
+# Creates Jenkins JNLP agents for cross-platform testing, starts the Docker
+# containers, and waits for them to come online.
+#
+# Prerequisites:
+#   - Jenkins running on localhost:8080 (admin/password)
+#   - The jfrog plugin HPI installed in Jenkins
+#   - Docker with multi-platform support (buildx)
+#
+# What it does:
+#   1. Enables the TCP slave agent listener (port 50000)
+#   2. Creates two permanent agents: agent-linux-amd64, agent-linux-arm64
+#   3. Configures the "releases-jfrog-cli" tool (Install from releases.jfrog.io)
+#   4. Starts Docker containers that connect back to Jenkins
+#   5. Creates a cross-platform test pipeline
+#
+# After running, trigger the test with:
+#   curl -X POST http://localhost:8080/job/test-cross-platform/build -u admin:password
+
+set -euo pipefail
+
+JENKINS_URL="${JENKINS_URL:-http://localhost:8080}"
+JENKINS_USER="${JENKINS_USER:-admin}"
+JENKINS_PASS="${JENKINS_PASS:-password}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+get_crumb() {
+  local cookies="$1"
+  curl -sf -c "$cookies" "${JENKINS_URL}/crumbIssuer/api/json" \
+    -u "${JENKINS_USER}:${JENKINS_PASS}" | python3 -c "import json,sys; print(json.load(sys.stdin)['crumb'])"
+}
+
+run_groovy() {
+  local script="$1"
+  local cookies
+  cookies=$(mktemp)
+  local crumb
+  crumb=$(get_crumb "$cookies")
+  curl -sf -X POST "${JENKINS_URL}/scriptText" \
+    -u "${JENKINS_USER}:${JENKINS_PASS}" \
+    -b "$cookies" \
+    -H "Jenkins-Crumb: ${crumb}" \
+    --data-urlencode "script=${script}"
+  rm -f "$cookies"
+}
+
+echo "==> Checking Jenkins is up..."
+if ! curl -sf "${JENKINS_URL}/api/json" -u "${JENKINS_USER}:${JENKINS_PASS}" > /dev/null 2>&1; then
+  echo "ERROR: Jenkins not reachable at ${JENKINS_URL}"
+  return 1
+fi
+
+echo "==> Enabling TCP slave agent listener on port 50000..."
+run_groovy '
+import jenkins.model.Jenkins
+def jenkins = Jenkins.instance
+jenkins.setSlaveAgentPort(50000)
+jenkins.save()
+println "TCP listener enabled on port: " + jenkins.getSlaveAgentPort()
+'
+
+echo ""
+echo "==> Creating agents and retrieving secrets..."
+SECRETS=$(run_groovy '
+import jenkins.model.*
+import hudson.model.*
+import hudson.slaves.*
+
+def createAgent(String name, String label) {
+    def jenkins = Jenkins.instance
+    if (jenkins.getNode(name) != null) {
+        jenkins.removeNode(jenkins.getNode(name))
+    }
+    def launcher = new JNLPLauncher(true)
+    def agent = new DumbSlave(name, "/home/jenkins/agent", launcher)
+    agent.setLabelString(label)
+    agent.setRetentionStrategy(RetentionStrategy.INSTANCE)
+    jenkins.addNode(agent)
+}
+
+createAgent("agent-linux-amd64", "linux-amd64")
+createAgent("agent-linux-arm64", "linux-arm64")
+
+Jenkins.instance.nodes.each { node ->
+    if (node.name.startsWith("agent-linux")) {
+        def computer = node.toComputer()
+        if (computer instanceof hudson.slaves.SlaveComputer) {
+            println "SECRET_${node.name.replace("-", "_").toUpperCase()}=${computer.getJnlpMac()}"
+        }
+    }
+}
+')
+
+echo "$SECRETS"
+
+# Parse secrets
+export AGENT_AMD64_SECRET=$(echo "$SECRETS" | grep "SECRET_AGENT_LINUX_AMD64" | cut -d= -f2)
+export AGENT_ARM64_SECRET=$(echo "$SECRETS" | grep "SECRET_AGENT_LINUX_ARM64" | cut -d= -f2)
+
+if [ -z "$AGENT_AMD64_SECRET" ] || [ -z "$AGENT_ARM64_SECRET" ]; then
+  echo "ERROR: Failed to retrieve agent secrets"
+  return 1
+fi
+
+echo ""
+echo "==> Pulling agent images (both platforms)..."
+docker pull --platform linux/amd64 jenkins/inbound-agent:latest
+docker pull --platform linux/arm64 jenkins/inbound-agent:latest
+
+echo ""
+echo "==> Starting agent containers..."
+docker compose -f "$SCRIPT_DIR/docker-compose-agents.yml" up -d
+
+echo ""
+echo "==> Waiting for agents to come online..."
+for i in $(seq 1 30); do
+  ONLINE_COUNT=$(run_groovy '
+    def count = Jenkins.instance.nodes.count { node ->
+      node.name.startsWith("agent-linux") && node.toComputer()?.isOnline()
+    }
+    print count
+  ')
+  if [ "$ONLINE_COUNT" = "2" ]; then
+    echo "==> Both agents are online!"
+    break
+  fi
+  echo "  ...waiting for agents ($ONLINE_COUNT/2 online, attempt $i/30)"
+  sleep 5
+done
+
+echo ""
+echo "==> Configuring JFrog CLI tool..."
+run_groovy '
+import jenkins.model.*
+import hudson.tools.*
+import io.jenkins.plugins.jfrog.*
+
+def jenkins = Jenkins.instance
+def desc = jenkins.getDescriptorByType(JfrogInstallation.DescriptorImpl.class)
+def existing = desc.getInstallations()?.toList() ?: []
+
+if (!existing.any { it.name == "releases-jfrog-cli" }) {
+    def installer = new ReleasesInstaller()
+    def props = new DescribableList(Saveable.NOOP)
+    props.add(new InstallSourceProperty([installer]))
+    def tool = new JfrogInstallation("releases-jfrog-cli", "", props)
+    existing.add(tool)
+    desc.setInstallations(existing.toArray(new JfrogInstallation[0]))
+    println "Tool releases-jfrog-cli configured"
+} else {
+    println "Tool releases-jfrog-cli already exists"
+}
+'
+
+echo ""
+echo "==> Creating cross-platform test pipeline..."
+COOKIES=$(mktemp)
+CRUMB=$(get_crumb "$COOKIES")
+
+# Delete if exists
+curl -sf -X POST "${JENKINS_URL}/job/test-cross-platform/doDelete" \
+  -u "${JENKINS_USER}:${JENKINS_PASS}" -b "$COOKIES" -H "Jenkins-Crumb: ${CRUMB}" 2>/dev/null || true
+
+CRUMB=$(get_crumb "$COOKIES")
+curl -sf -X POST "${JENKINS_URL}/createItem?name=test-cross-platform" \
+  -u "${JENKINS_USER}:${JENKINS_PASS}" -b "$COOKIES" -H "Jenkins-Crumb: ${CRUMB}" \
+  -H "Content-Type: application/xml" \
+  --data-binary @- << 'XMLEOF'
+<?xml version='1.1' encoding='UTF-8'?>
+<flow-definition plugin="workflow-job">
+  <description>Cross-platform JFrog CLI installation test.
+Tests: per-pipeline cache, agent OS detection, multi-arch binary download.</description>
+  <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps">
+    <script>
+pipeline {
+    agent none
+    stages {
+        stage("Mac/Host Controller") {
+            agent { label "built-in" }
+            tools { jfrog "releases-jfrog-cli" }
+            steps {
+                echo "Running on controller"
+                sh "uname -m &amp;&amp; uname -s"
+            }
+        }
+        stage("Mac/Host Controller Again") {
+            agent { label "built-in" }
+            tools { jfrog "releases-jfrog-cli" }
+            steps {
+                echo "Same agent - expect cache hit, no BinaryInstaller messages"
+                sh "uname -m"
+            }
+        }
+        stage("Linux AMD64") {
+            agent { label "linux-amd64" }
+            tools { jfrog "releases-jfrog-cli" }
+            steps {
+                echo "Running on Linux AMD64 agent"
+                sh "uname -m &amp;&amp; uname -s"
+                sh "/home/jenkins/agent/tools/io.jenkins.plugins.jfrog.JfrogInstallation/releases-jfrog-cli/jf --version"
+            }
+        }
+        stage("Linux ARM64") {
+            agent { label "linux-arm64" }
+            tools { jfrog "releases-jfrog-cli" }
+            steps {
+                echo "Running on Linux ARM64 agent"
+                sh "uname -m &amp;&amp; uname -s"
+                sh "/home/jenkins/agent/tools/io.jenkins.plugins.jfrog.JfrogInstallation/releases-jfrog-cli/jf --version"
+            }
+        }
+        stage("Linux AMD64 Again") {
+            agent { label "linux-amd64" }
+            tools { jfrog "releases-jfrog-cli" }
+            steps {
+                echo "Same AMD64 agent - expect cache hit"
+                sh "uname -m"
+            }
+        }
+        stage("Linux ARM64 Again") {
+            agent { label "linux-arm64" }
+            tools { jfrog "releases-jfrog-cli" }
+            steps {
+                echo "Same ARM64 agent - expect cache hit"
+                sh "uname -m"
+            }
+        }
+    }
+}
+    </script>
+    <sandbox>true</sandbox>
+  </definition>
+</flow-definition>
+XMLEOF
+
+rm -f "$COOKIES"
+
+echo ""
+echo "==> Setup complete!"
+echo ""
+echo "Agents:"
+run_groovy '
+Jenkins.instance.nodes.each { node ->
+    def c = node.toComputer()
+    println "  ${node.name}: online=${c?.isOnline()}, label=${node.labelString}"
+}
+'
+echo ""
+echo "To run the cross-platform test:"
+echo "  curl -X POST ${JENKINS_URL}/job/test-cross-platform/build -u ${JENKINS_USER}:${JENKINS_PASS}"
+echo ""
+echo "To view results:"
+echo "  curl ${JENKINS_URL}/job/test-cross-platform/lastBuild/consoleText -u ${JENKINS_USER}:${JENKINS_PASS}"
+echo ""
+echo "To enable FINE logging for debug:"
+echo "  Manage Jenkins → System Log → Add 'io.jenkins.plugins.jfrog.BinaryInstaller' at FINE"
+echo ""
+echo "To tear down agents:"
+echo "  docker compose -f e2e/local/docker-compose-agents.yml down"

--- a/src/main/java/io/jenkins/plugins/jfrog/ArtifactoryInstaller.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/ArtifactoryInstaller.java
@@ -56,7 +56,7 @@ public class ArtifactoryInstaller extends BinaryInstaller {
             throw new IOException("Server id '" + getServerId() + "' doesn't exists.");
         }
         String binaryName = Utils.getJfrogCliBinaryName(!node.createLauncher(log).isUnix());
-        return performJfrogCliInstallation(getToolLocation(tool, node), log, getVersion(), server, getRepository(), binaryName);
+        return performJfrogCliInstallation(getToolLocation(tool, node), log, getVersion(), server, getRepository(), binaryName, node.getNodeName());
     }
 
     /**

--- a/src/main/java/io/jenkins/plugins/jfrog/BinaryInstaller.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/BinaryInstaller.java
@@ -145,10 +145,10 @@ public abstract class BinaryInstaller extends ToolInstaller {
         // Cache agent OS per node+path to handle agents with identical tool paths but different architectures.
         String toolPath = toolLocation.getRemote();
         String osCacheKey = nodeName + ":" + toolPath;
-        String agentOs = AGENT_OS_CACHE.get(osCacheKey);
-        if (agentOs == null) {
+        evictIfFull(AGENT_OS_CACHE);
+        String agentOs = AGENT_OS_CACHE.computeIfAbsent(osCacheKey, k -> {
             try {
-                agentOs = toolLocation.act(new MasterToSlaveFileCallable<String>() {
+                return toolLocation.act(new MasterToSlaveFileCallable<String>() {
                     @Override
                     public String invoke(File f, VirtualChannel channel) throws IOException {
                         return OsUtils.getOsDetails();
@@ -156,13 +156,9 @@ public abstract class BinaryInstaller extends ToolInstaller {
                 });
             } catch (Exception e) {
                 LOGGER.warning("Failed to get agent OS details: " + e.getMessage());
-                agentOs = "unknown";
+                return "unknown";
             }
-            if (AGENT_OS_CACHE.size() >= MAX_CACHE_SIZE) {
-                AGENT_OS_CACHE.clear();
-            }
-            AGENT_OS_CACHE.put(osCacheKey, agentOs);
-        }
+        });
 
         String cacheKey = nodeName + ":" + toolPath + "/" + agentOs + "/" + binaryName;
         LOGGER.fine("Agent OS detected: " + agentOs + " for node: " + nodeName + " tool: " + toolPath);
@@ -308,10 +304,19 @@ public abstract class BinaryInstaller extends ToolInstaller {
         if (currentRunId == null) {
             return;
         }
-        if (VERIFIED_IN_RUN.size() >= MAX_CACHE_SIZE) {
-            VERIFIED_IN_RUN.clear();
-        }
+        evictIfFull(VERIFIED_IN_RUN);
         VERIFIED_IN_RUN.put(cacheKey, currentRunId);
+    }
+
+    /**
+     * Clears the cache if it has reached {@link #MAX_CACHE_SIZE}.
+     * This is a simple eviction strategy — the slight race between size() and clear()
+     * is harmless (worst case: one extra entry before eviction, or an extra cache miss).
+     */
+    private static void evictIfFull(ConcurrentHashMap<String, String> cache) {
+        if (cache.size() >= MAX_CACHE_SIZE) {
+            cache.clear();
+        }
     }
 
     /**

--- a/src/main/java/io/jenkins/plugins/jfrog/BinaryInstaller.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/BinaryInstaller.java
@@ -20,6 +20,9 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
@@ -63,8 +66,8 @@ public abstract class BinaryInstaller extends ToolInstaller {
     private static final ConcurrentHashMap<String, ReentrantLock> NODE_INSTALLATION_LOCKS = new ConcurrentHashMap<>();
 
     /**
-     * Per-pipeline installation verification cache.
-     * Key: tool path + agent OS + binary name
+     * Per-pipeline installation verification cache (LRU, max 1000 entries).
+     * Key: nodeName + tool path + agent OS + binary name
      * Value: pipeline run identifier (derived from the build's log storage)
      *
      * <p>Once a tool is verified in a pipeline run, all subsequent stages in the same run
@@ -73,15 +76,29 @@ public abstract class BinaryInstaller extends ToolInstaller {
      * The agent OS is included in the key to distinguish same-path installations on
      * agents with different architectures (e.g., linux-amd64 vs linux-arm64).</p>
      */
-    private static final ConcurrentHashMap<String, String> VERIFIED_IN_RUN = new ConcurrentHashMap<>();
-    private static final int MAX_CACHE_SIZE = 100;
+    private static final int MAX_CACHE_SIZE = 1000;
+    private static final Map<String, String> VERIFIED_IN_RUN = Collections.synchronizedMap(
+            new LinkedHashMap<String, String>(MAX_CACHE_SIZE, 0.75f, true) {
+                @Override
+                protected boolean removeEldestEntry(Map.Entry<String, String> eldest) {
+                    return size() > MAX_CACHE_SIZE;
+                }
+            });
 
     /**
-     * Cache of agent OS details to avoid repeated remote calls.
-     * Key: tool location remote path
+     * Cache of agent OS details to avoid repeated remote calls (LRU, max 100 entries).
+     * Key: nodeName + tool location remote path
      * Value: OS details string (e.g., "linux-amd64", "mac-arm64")
      */
-    private static final ConcurrentHashMap<String, String> AGENT_OS_CACHE = new ConcurrentHashMap<>();
+    private static final Map<String, String> AGENT_OS_CACHE = Collections.synchronizedMap(
+            new LinkedHashMap<String, String>(MAX_CACHE_SIZE, 0.75f, true) {
+                @Override
+                protected boolean removeEldestEntry(Map.Entry<String, String> eldest) {
+                    return size() > MAX_CACHE_SIZE;
+                }
+            });
+
+    private static final String BUILT_IN_NODE = "built-in";
 
     protected BinaryInstaller(String label) {
         super(label);
@@ -142,13 +159,16 @@ public abstract class BinaryInstaller extends ToolInstaller {
 
         FilePath cliPath = toolLocation.child(binaryName);
 
+        // Node.getNodeName() returns "" for the built-in (master) node.
+        String node = StringUtils.defaultIfBlank(nodeName, BUILT_IN_NODE);
+
         // Cache agent OS per node+path to handle agents with identical tool paths but different architectures.
         String toolPath = toolLocation.getRemote();
-        String osCacheKey = nodeName + ":" + toolPath;
-        evictIfFull(AGENT_OS_CACHE);
-        String agentOs = AGENT_OS_CACHE.computeIfAbsent(osCacheKey, k -> {
+        String osCacheKey = node + ":" + toolPath;
+        String agentOs = AGENT_OS_CACHE.get(osCacheKey);
+        if (agentOs == null) {
             try {
-                return toolLocation.act(new MasterToSlaveFileCallable<String>() {
+                agentOs = toolLocation.act(new MasterToSlaveFileCallable<String>() {
                     @Override
                     public String invoke(File f, VirtualChannel channel) throws IOException {
                         return OsUtils.getOsDetails();
@@ -156,12 +176,13 @@ public abstract class BinaryInstaller extends ToolInstaller {
                 });
             } catch (Exception e) {
                 LOGGER.warning("Failed to get agent OS details: " + e.getMessage());
-                return "unknown";
+                agentOs = "unknown";
             }
-        });
+            AGENT_OS_CACHE.put(osCacheKey, agentOs);
+        }
 
-        String cacheKey = nodeName + ":" + toolPath + "/" + agentOs + "/" + binaryName;
-        LOGGER.fine("Agent OS detected: " + agentOs + " for node: " + nodeName + " tool: " + toolPath);
+        String cacheKey = node + ":" + toolPath + "/" + agentOs + "/" + binaryName;
+        LOGGER.fine("Agent OS detected: " + agentOs + " for node: " + node + " tool: " + toolPath);
 
         // Per-pipeline cache: skip re-verification if already checked in this pipeline run.
         String currentRunId = getCurrentRunId(log);
@@ -304,19 +325,7 @@ public abstract class BinaryInstaller extends ToolInstaller {
         if (currentRunId == null) {
             return;
         }
-        evictIfFull(VERIFIED_IN_RUN);
         VERIFIED_IN_RUN.put(cacheKey, currentRunId);
-    }
-
-    /**
-     * Clears the cache if it has reached {@link #MAX_CACHE_SIZE}.
-     * This is a simple eviction strategy — the slight race between size() and clear()
-     * is harmless (worst case: one extra entry before eviction, or an extra cache miss).
-     */
-    private static void evictIfFull(ConcurrentHashMap<String, String> cache) {
-        if (cache.size() >= MAX_CACHE_SIZE) {
-            cache.clear();
-        }
     }
 
     /**

--- a/src/main/java/io/jenkins/plugins/jfrog/BinaryInstaller.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/BinaryInstaller.java
@@ -61,7 +61,28 @@ public abstract class BinaryInstaller extends ToolInstaller {
      * next access).</p>
      */
     private static final ConcurrentHashMap<String, ReentrantLock> NODE_INSTALLATION_LOCKS = new ConcurrentHashMap<>();
-    
+
+    /**
+     * Per-pipeline installation verification cache.
+     * Key: tool path + agent OS + binary name
+     * Value: pipeline run identifier (derived from the build's log storage)
+     *
+     * <p>Once a tool is verified in a pipeline run, all subsequent stages in the same run
+     * skip the version check entirely — avoiding repeated HTTP HEAD requests to Artifactory.
+     * A new pipeline run produces a different run ID, so it gets its own verification.
+     * The agent OS is included in the key to distinguish same-path installations on
+     * agents with different architectures (e.g., linux-amd64 vs linux-arm64).</p>
+     */
+    private static final ConcurrentHashMap<String, String> VERIFIED_IN_RUN = new ConcurrentHashMap<>();
+    private static final int MAX_CACHE_SIZE = 100;
+
+    /**
+     * Cache of agent OS details to avoid repeated remote calls.
+     * Key: tool location remote path
+     * Value: OS details string (e.g., "linux-amd64", "mac-arm64")
+     */
+    private static final ConcurrentHashMap<String, String> AGENT_OS_CACHE = new ConcurrentHashMap<>();
+
     protected BinaryInstaller(String label) {
         super(label);
     }
@@ -115,14 +136,48 @@ public abstract class BinaryInstaller extends ToolInstaller {
      * @throws InterruptedException If installation is interrupted
      */
     public static FilePath performJfrogCliInstallation(FilePath toolLocation, TaskListener log, String version,
-                                                       JFrogPlatformInstance instance, String repository, String binaryName)
+                                                       JFrogPlatformInstance instance, String repository,
+                                                       String binaryName, String nodeName)
             throws IOException, InterruptedException {
 
         FilePath cliPath = toolLocation.child(binaryName);
 
+        // Cache agent OS per node+path to handle agents with identical tool paths but different architectures.
+        String toolPath = toolLocation.getRemote();
+        String osCacheKey = nodeName + ":" + toolPath;
+        String agentOs = AGENT_OS_CACHE.get(osCacheKey);
+        if (agentOs == null) {
+            try {
+                agentOs = toolLocation.act(new MasterToSlaveFileCallable<String>() {
+                    @Override
+                    public String invoke(File f, VirtualChannel channel) throws IOException {
+                        return OsUtils.getOsDetails();
+                    }
+                });
+            } catch (Exception e) {
+                LOGGER.warning("Failed to get agent OS details: " + e.getMessage());
+                agentOs = "unknown";
+            }
+            if (AGENT_OS_CACHE.size() >= MAX_CACHE_SIZE) {
+                AGENT_OS_CACHE.clear();
+            }
+            AGENT_OS_CACHE.put(osCacheKey, agentOs);
+        }
+
+        String cacheKey = nodeName + ":" + toolPath + "/" + agentOs + "/" + binaryName;
+        LOGGER.fine("Agent OS detected: " + agentOs + " for node: " + nodeName + " tool: " + toolPath);
+
+        // Per-pipeline cache: skip re-verification if already checked in this pipeline run.
+        String currentRunId = getCurrentRunId(log);
+        if (currentRunId != null && currentRunId.equals(VERIFIED_IN_RUN.get(cacheKey))) {
+            LOGGER.fine("CLI already verified in this pipeline run, skipping check for: " + cacheKey);
+            return toolLocation;
+        }
+
         // Fast path: binary exists and is already the correct version — skip lock entirely.
-        if (isValidCliInstallation(cliPath, log) && isCorrectVersion(toolLocation, instance, repository, version, binaryName, log)) {
+        if (isValidCliInstallation(cliPath, log) && isCorrectVersion(toolLocation, instance, repository, version, binaryName, agentOs, log)) {
             log.getLogger().println("[BinaryInstaller] CLI already installed and up-to-date, skipping download");
+            markVerified(cacheKey, currentRunId);
             return toolLocation;
         }
 
@@ -147,8 +202,9 @@ public abstract class BinaryInstaller extends ToolInstaller {
         try {
             // Re-check inside the lock — a concurrent stage may have just finished.
             boolean validCliExists = isValidCliInstallation(cliPath, log);
-            if (validCliExists && isCorrectVersion(toolLocation, instance, repository, version, binaryName, log)) {
+            if (validCliExists && isCorrectVersion(toolLocation, instance, repository, version, binaryName, agentOs, log)) {
                 log.getLogger().println("[BinaryInstaller] CLI was installed by a concurrent stage, skipping download");
+                markVerified(cacheKey, currentRunId);
                 return toolLocation;
             }
 
@@ -162,6 +218,7 @@ public abstract class BinaryInstaller extends ToolInstaller {
                 JenkinsProxyConfiguration proxyConfiguration = new JenkinsProxyConfiguration();
                 toolLocation.act(new JFrogCliDownloader(proxyConfiguration, version, instance, log, repository, binaryName));
                 log.getLogger().println("[BinaryInstaller] CLI installation completed successfully");
+                markVerified(cacheKey, currentRunId);
             } catch (Exception e) {
                 // Download failed. If an older binary is still present, keep the pipeline running.
                 // The upgrade will be retried on the next run.
@@ -205,12 +262,61 @@ public abstract class BinaryInstaller extends ToolInstaller {
     }
 
     /**
+     * Extracts a unique pipeline run identifier from the TaskListener.
+     * <p>
+     * In Pipeline builds, the TaskListener wraps a FileLogStorage whose log file path
+     * contains the job name and build number (e.g., "jobs/my-job/builds/42/log").
+     * This path is guaranteed unique per pipeline run.
+     * <p>
+     * Falls back to null for non-Pipeline builds (Freestyle, etc.) where the listener
+     * structure is different — the caller treats null as "don't cache".
+     * <p>
+     * <b>Fragile:</b> This relies on internal field names in workflow-api and workflow-support.
+     * Tested with Jenkins {@literal >=} 2.462.3 and workflow-cps. If a future Jenkins update
+     * renames these fields, the catch block returns null and caching degrades gracefully
+     * (repeated version checks, no failure). Re-verify after major Jenkins core upgrades.
+     */
+    private static String getCurrentRunId(TaskListener log) {
+        try {
+            // Reflection chain (workflow-api / workflow-support internals):
+            // CloseableTaskListener → mainDelegate (BufferedBuildListener) → out (IndexOutputStream) → this$0 (FileLogStorage) → log (File)
+            java.lang.reflect.Field mainField = log.getClass().getDeclaredField("mainDelegate");
+            mainField.setAccessible(true);
+            Object buildListener = mainField.get(log);
+
+            java.lang.reflect.Field outField = buildListener.getClass().getDeclaredField("out");
+            outField.setAccessible(true);
+            Object indexOut = outField.get(buildListener);
+
+            java.lang.reflect.Field storageField = indexOut.getClass().getDeclaredField("this$0");
+            storageField.setAccessible(true);
+            Object fileLogStorage = storageField.get(indexOut);
+
+            java.lang.reflect.Field logField = fileLogStorage.getClass().getDeclaredField("log");
+            logField.setAccessible(true);
+            File logFile = (File) logField.get(fileLogStorage);
+
+            return logFile.getPath();
+        } catch (Exception e) {
+            // Non-Pipeline build or different Jenkins version — fall back gracefully
+            LOGGER.fine("Could not determine pipeline run ID: " + e.getMessage());
+            return null;
+        }
+    }
+
+    private static void markVerified(String cacheKey, String currentRunId) {
+        if (currentRunId == null) {
+            return;
+        }
+        if (VERIFIED_IN_RUN.size() >= MAX_CACHE_SIZE) {
+            VERIFIED_IN_RUN.clear();
+        }
+        VERIFIED_IN_RUN.put(cacheKey, currentRunId);
+    }
+
+    /**
      * Creates a unique lock key for the installation location.
      * Version is excluded so all operations targeting the same binary path are serialized.
-     *
-     * @param toolLocation Installation directory
-     * @param binaryName Binary file name
-     * @return Unique lock key string
      */
     private static String createLockKey(FilePath toolLocation, String binaryName) {
         try {
@@ -267,17 +373,14 @@ public abstract class BinaryInstaller extends ToolInstaller {
      * @param log Task listener for logging
      * @return true if CLI is the correct version, false otherwise
      */
-    private static boolean isCorrectVersion(FilePath toolLocation, JFrogPlatformInstance instance, 
-                                          String repository, String version, String binaryName, TaskListener log) {
+    private static boolean isCorrectVersion(FilePath toolLocation, JFrogPlatformInstance instance,
+                                          String repository, String version, String binaryName,
+                                          String agentOsDetails, TaskListener log) {
         try {
-            // Use the same logic as shouldDownloadTool() from JFrogCliDownloader
-            // but do it here to avoid unnecessary JFrogCliDownloader.invoke() calls
-            
             JenkinsProxyConfiguration proxyConfiguration = new JenkinsProxyConfiguration();
-            // Use binaryName to construct the correct URL suffix (handles Windows jf.exe vs Unix jf)
-            String cliUrlSuffix = String.format("/%s/v2-jf/%s/jfrog-cli-%s/%s", repository, 
-                                               StringUtils.defaultIfBlank(version, "[RELEASE]"), 
-                                               OsUtils.getOsDetails(), binaryName);
+            String cliUrlSuffix = String.format("/%s/v2-jf/%s/jfrog-cli-%s/%s", repository,
+                                               StringUtils.defaultIfBlank(version, "[RELEASE]"),
+                                               agentOsDetails, binaryName);
             
             JenkinsBuildInfoLog buildInfoLog = new JenkinsBuildInfoLog(log);
             String artifactoryUrl = instance.inferArtifactoryUrl();
@@ -295,6 +398,8 @@ public abstract class BinaryInstaller extends ToolInstaller {
                 String expectedSha256 = getArtifactSha256(manager, cliUrlSuffix);
                 if (expectedSha256.isEmpty()) {
                     log.getLogger().println("[BinaryInstaller] WARNING: No SHA256 available from server — cannot verify version, assuming up-to-date (upgrade may be delayed)");
+                    // Clean up stale 0-byte sha256 file left by older plugin versions
+                    cleanupStaleSha256File(toolLocation, log);
                     return true;
                 }
                 
@@ -316,6 +421,31 @@ public abstract class BinaryInstaller extends ToolInstaller {
         } catch (Exception e) {
             log.getLogger().println("[BinaryInstaller] Version check failed: " + e.getMessage() + ", proceeding with download check");
             return false; // If version check fails, let download process handle it
+        }
+    }
+
+    /**
+     * Removes a stale 0-byte sha256 file left behind by older plugin versions.
+     * The file has no effect on current behaviour but can confuse operators inspecting
+     * the tool directory.
+     */
+    private static void cleanupStaleSha256File(FilePath toolLocation, TaskListener log) {
+        try {
+            toolLocation.act(new MasterToSlaveFileCallable<Void>() {
+                @Override
+                public Void invoke(File f, VirtualChannel channel) throws IOException {
+                    File sha256File = new File(f, "sha256");
+                    if (sha256File.exists() && sha256File.length() == 0) {
+                        if (sha256File.delete()) {
+                            log.getLogger().println("[BinaryInstaller] Cleaned up stale 0-byte sha256 file");
+                        }
+                    }
+                    return null;
+                }
+            });
+        } catch (Exception e) {
+            // Best-effort cleanup — not worth failing the build
+            LOGGER.warning("Failed to clean up stale sha256 file: " + e.getMessage());
         }
     }
 


### PR DESCRIPTION
- [ ] This pull request is created in the [jfrog/jenkins-jfrog-plugin](https://github.com/jfrog/jenkins-jfrog-plugin) repository.
## Description

  - Add per-pipeline verification cache to eliminate repeated HTTP HEAD
    requests to Artifactory across stages. Jenkins calls performInstallation
    for every stage (tool + envVarsForTool), causing 10+ redundant checks
    per pipeline. Now only the first call per pipeline run does the full
    check; subsequent stages skip instantly.

  - Fix cross-platform OS mismatch in isCorrectVersion(). Previously used
    OsUtils.getOsDetails() on the controller, producing wrong URLs when
    controller and agent have different OS/arch (e.g., linux-amd64 controller
    + mac-arm64 agent). Now fetches agent OS via toolLocation.act() callable
    and includes node name in cache keys to prevent collisions between agents
    sharing identical tool paths but different architectures.

  - Clean up stale 0-byte sha256 files left by older plugin versions that
    wrote empty checksums when the SHA256 header was unavailable.

  - Add local e2e setup for multi-arch Jenkins agent testing with Docker
    containers (linux/amd64 + linux/arm64 JNLP agents).
