### PR TITLE
fix: declare explicit dependency on jackson-annotations2-api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,19 @@
             <artifactId>jackson2-api</artifactId>
         </dependency>
         <dependency>
+            <!--
+                jackson2-api 2.19+ delegates jackson-annotations to a separate
+                jackson-annotations2-api plugin. Declare it explicitly so the
+                generated Plugin-Dependencies manifest entry lets the jfrog
+                plugin classloader resolve JsonInclude$Include through the
+                same loader jackson2-api uses, avoiding a LinkageError
+                (loader constraint violation) at runtime.
+            -->
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>jackson-annotations2-api</artifactId>
+            <version>2.21-7.v4777a_f3a_a_d47</version>
+        </dependency>
+        <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>plain-credentials</artifactId>
         </dependency>


### PR DESCRIPTION
## Summary

Fixes a `java.lang.LinkageError` (loader constraint violation) that prevents `JfStep` from initializing on Jenkins controllers running `jackson2-api` 2.19 or newer.

## Problem

Starting with `jackson2-api` 2.19, the plugin was split: `jackson-annotations` was moved into a separate `jackson-annotations2-api` Jenkins plugin. The `jfrog` plugin still declares a dependency only on `jackson2-api`, so `com.fasterxml.jackson.annotation.JsonInclude$Include` is visible to `BuildInfoExtractorUtils` via one `PluginClassLoader` and to `ObjectMapper.setSerializationInclusion(...)` via another.

When `JfStep.<clinit>` calls `BuildInfoExtractorUtils.createMapper` the JVM sees two different `Class` objects for the same FQN and refuses method resolution:

```
java.lang.LinkageError: loader constraint violation: when resolving method
'com.fasterxml.jackson.databind.ObjectMapper
 com.fasterxml.jackson.databind.ObjectMapper.setSerializationInclusion(
  com.fasterxml.jackson.annotation.JsonInclude$Include)'
the class loader 'PluginClassLoader for jfrog'  ... and the class loader
'PluginClassLoader for jackson2-api' ... have different Class objects for
the type com/fasterxml/jackson/annotation/JsonInclude$Include ...
    at org.jfrog.build.extractor.BuildInfoExtractorUtils.createMapper(...:341)
    at io.jenkins.plugins.jfrog.JfStep.<clinit>(JfStep.java:46)
```

## Fix

Declare `io.jenkins.plugins:jackson-annotations2-api` explicitly in `pom.xml`. The `maven-hpi-plugin` then emits it inside the `Plugin-Dependencies` manifest entry so Jenkins delegates annotation class loading through the same loader `jackson2-api` uses.

The dependency is pinned because the current `bom-2.462.x` does not manage `jackson-annotations2-api` yet.

## Verification

Rebuilt plugin. The resulting HPI manifest now contains both plugin dependencies:

```
Plugin-Dependencies: ..., jackson-annotations2-api:2.21-7.v4777af3aad47,
 ..., jackson2-api:2.21.2-433.v6d50b92cfe52, ...
```

After installing the patched HPI on the affected controller the `LinkageError` no longer occurs and `jf` pipeline steps run as before.

Fixes #150

## Test plan

- [ ] CI builds the plugin
- [ ] Install the resulting HPI on a Jenkins controller that has `jackson2-api` >= 2.19
- [ ] Run a pipeline that uses `tools { jfrog 'jfrog-cli' }` and confirm `JfStep` initializes without a `LinkageError`