### PR TITLE
RTECO-1280 - Make jf audit optional in snapshot pipeline

### DIFF
--- a/.jfrog-pipelines/pipelines.snapshot.yml
+++ b/.jfrog-pipelines/pipelines.snapshot.yml
@@ -7,6 +7,14 @@ pipelines:
           custom:
             name: releases-docker.jfrog.io/jfrog-ecosystem-integration-env
             tag: 1.9.0
+      environmentVariables:
+        readOnly:
+          RUN_JF_AUDIT:
+            default: "false"
+            values:
+              - "false"
+              - "true"
+            allowCustom: false
 
     steps:
       - name: Snapshot
@@ -37,7 +45,7 @@ pipelines:
             - jf mvnc --repo-resolve-releases ecosys-jenkins-repos --repo-resolve-snapshots ecosys-releases-snapshots --repo-deploy-snapshots ecosys-oss-snapshot-local --repo-deploy-releases ecosys-oss-release-local
 
             # Run audit
-            - jf audit --fail=false
+            - if [ "$RUN_JF_AUDIT" = "true" ]; then jf audit --fail=false; else echo "Skipping jf audit"; fi
 
             # Delete former snapshots to make sure the release bundle will not contain the same artifacts
             - jf rt del "ecosys-oss-snapshot-local/org/jenkins-ci/plugins/jfrog/*" --quiet


### PR DESCRIPTION
Add RUN_JF_AUDIT pipeline variable (default: false) to the snapshot pipeline, matching the existing pattern in the release pipeline.

- [x] This pull request is created in the [jfrog/jenkins-jfrog-plugin](https://github.com/jfrog/jenkins-jfrog-plugin) repository.
