### PR TITLE
Fix duplicate log output on Kubernetes agents

### DIFF
--- a/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
@@ -70,10 +70,16 @@ public class JfStep extends Step {
         try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
             ArgumentListBuilder builder = new ArgumentListBuilder();
             builder.add(jfrogBinaryPath).add("-v");
+            // quiet(true) keeps this internal version-detection command off the build console.
+            // Its output is captured into outputStream for parsing only. Without quiet, the
+            // Kubernetes plugin's ContainerExecDecorator mirrors process output to
+            // launcher.getListener().getLogger() (the console) in addition to our capture stream,
+            // leaking "jf version X.Y.Z" to the log and appearing as duplicated output on K8s agents.
             int exitCode = launcher
                     .cmds(builder)
                     .pwd(launcher.pwd())
                     .stdout(outputStream)
+                    .quiet(true)
                     .join();
             if (exitCode != 0) {
                 throw new IOException("Failed to get JFrog CLI version: " + outputStream.toString(StandardCharsets.UTF_8));
@@ -204,7 +210,13 @@ public class JfStep extends Step {
             }
             FilePath jfrogHomeTempDir = Utils.createAndGetJfrogCliHomeTempDir(workspace, String.valueOf(run.getNumber()));
             CliEnvConfigurator.configureCliEnv(env, jfrogHomeTempDir, jfrogCliConfigEncryption);
-            Launcher.ProcStarter jfLauncher = launcher.launch().envs(env).pwd(workspace).stdout(listener);
+            // quiet(true) makes our JfTaskListener the sole writer of the command's output to the console.
+            // Some launchers (notably the Kubernetes plugin's ContainerExecDecorator) additionally mirror
+            // process output to launcher.getListener().getLogger() when not quiet. Since our stdout listener
+            // already tees to the same console, that would print every line twice. quiet(true) suppresses
+            // that extra sink (it also suppresses the masked command-line echo) so output is printed once
+            // on every agent type. See https://github.com/jenkinsci/kubernetes-plugin ContainerExecDecorator.
+            Launcher.ProcStarter jfLauncher = launcher.launch().envs(env).pwd(workspace).stdout(listener).quiet(true);
             // Configure all servers, skip if all server ids have already been configured.
             if (shouldConfig(jfrogHomeTempDir)) {
                 logIfNoToolProvided(env, listener);

--- a/src/main/java/io/jenkins/plugins/jfrog/JfrogBuilder.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfrogBuilder.java
@@ -248,7 +248,13 @@ public class JfrogBuilder extends Builder {
 
         FilePath jfrogHomeTempDir = Utils.createAndGetJfrogCliHomeTempDir(workspace, String.valueOf(run.getNumber()));
         CliEnvConfigurator.configureCliEnv(env, jfrogHomeTempDir, jfrogCliConfigEncryption);
-        Launcher.ProcStarter jfLauncher = launcher.launch().envs(env).pwd(workspace).stdout(cliOutputListener);
+        // quiet(true) makes our JfTaskListener the sole writer of the command's output to the console.
+        // Some launchers (notably the Kubernetes plugin's ContainerExecDecorator) additionally mirror
+        // process output to launcher.getListener().getLogger() when not quiet. Since our stdout listener
+        // already tees to the same console, that would print every line twice. quiet(true) suppresses
+        // that extra sink (it also suppresses the masked command-line echo) so output is printed once
+        // on every agent type. See https://github.com/jenkinsci/kubernetes-plugin ContainerExecDecorator.
+        Launcher.ProcStarter jfLauncher = launcher.launch().envs(env).pwd(workspace).stdout(cliOutputListener).quiet(true);
 
         // Configure all servers, skip if all server ids have already been configured.
         if (shouldConfig(jfrogHomeTempDir)) {

--- a/src/test/java/io/jenkins/plugins/jfrog/JfStepTest.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/JfStepTest.java
@@ -23,6 +23,7 @@ import static io.jenkins.plugins.jfrog.JfStep.MIN_CLI_VERSION_PASSWORD_STDIN;
 import static io.jenkins.plugins.jfrog.JfrogInstallation.JFROG_BINARY_PATH;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.*;
 /**
  * @author yahavi
@@ -69,6 +70,7 @@ public class JfStepTest {
             out.write(outputStream.toByteArray());
             return procStarter;
         });
+        when(procStarter.quiet(anyBoolean())).thenReturn(procStarter);
         when(procStarter.join()).thenReturn(0);
 
         // Create an instance of JfStep and call the method


### PR DESCRIPTION
## Problem

When using the JFrog Jenkins plugin with Kubernetes-based agents, JFrog CLI command output is **duplicated** — each log line is printed twice in the build console. This does not occur on other agent types.

Example (from a real build):
```
Executing command: ".../jf" "c" "add" "jfrog-saas" ...
08:26:25 [Warn] failed while trying to check latest JFrog CLI version: ...
08:26:25 [Warn] failed while trying to check latest JFrog CLI version: ...
```

## Root cause

The Kubernetes plugin's `ContainerExecDecorator`, when a process is launched **without `quiet=true`**, mirrors process output to **two sinks**:

1. `launcher.getListener().getLogger()` — the build console (its own `printStream`)
2. the caller's `stdout` stream — which in this plugin is `JfTaskListener`, and that already tees to the same build console

So every line is written to the console twice. Other agent types do not insert this decorator, so they are unaffected.

Three launch paths ran without `quiet`:

| Path | Command | Symptom |
|------|---------|---------|
| `setupJFrogEnvironment` → `configAllServers` | `jf c add` | doubled server-config output (e.g. the `[Warn]` above) |
| `setupJFrogEnvironment` → actual step | `jf <args>` | every command's output doubled |
| `getJfrogCliVersion` | internal `jf -v` | version string captured for parsing leaked to the console |

## Fix

Set `quiet(true)` on all three `ProcStarter` chains (`JfStep` ×2, `JfrogBuilder` ×1). `quiet(true)` drops the decorator's extra console sink (and the masked command-line echo), leaving `JfTaskListener` as the **sole** console writer — so output prints exactly once on every agent type.

Captured output (build-info URL extraction, version parsing) is unaffected, because it flows through the caller stream, which `quiet` does not touch.

## Testing

- Reproduced on a local `kind` cluster with `mvn hpi:run`: output appeared twice before, once after.
- Instrumented the running build to confirm the launcher was `ContainerExecDecorator` and the quiet flag was applied at runtime.
- Unit tests pass (updated `getJfrogCliVersionTest` mock to stub the new `.quiet()` call).