### PR TITLE
RTFACT-31482: Fix invalid Build Info URLs for nested Jenkins folder jobs

### DIFF
--- a/src/main/java/io/jenkins/plugins/jfrog/CliEnvConfigurator.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/CliEnvConfigurator.java
@@ -35,8 +35,11 @@ public class CliEnvConfigurator {
      * @throws InterruptedException if the operation is interrupted
      */
     static void configureCliEnv(EnvVars env, FilePath jfrogHomeTempDir, JFrogCliConfigEncryption encryptionKey) throws IOException, InterruptedException {
-        // Setting Jenkins job name as the default build-info name
-        env.putIfAbsent(JFROG_CLI_BUILD_NAME, env.get("JOB_NAME"));
+        // Setting Jenkins job name as the default build-info name.
+        // For nested folder jobs, JOB_NAME contains folder separators ('/'), which produce invalid
+        // Build Info URLs after publication. Sanitize the name to restore the backward-compatible
+        // behavior of the legacy Artifactory plugin, which replaced '/' (and '%2F') with ' :: '.
+        env.putIfAbsent(JFROG_CLI_BUILD_NAME, sanitizeBuildName(env.get("JOB_NAME")));
         // Setting Jenkins build number as the default build-info number
         env.putIfAbsent(JFROG_CLI_BUILD_NUMBER, env.get("BUILD_NUMBER"));
         // Setting the specific build URL
@@ -55,6 +58,26 @@ public class CliEnvConfigurator {
             String keyFilePath = encryptionKey.writeKeyFile(jfrogHomeTempDir);
             env.put(JFROG_CLI_ENCRYPTION_KEY, keyFilePath);
         }
+    }
+
+    /**
+     * Replaces occurrences of '/' and '%2F' with ' :: ' if they exist.
+     * <p>
+     * Nested Jenkins folder jobs expose a JOB_NAME that contains folder separators (e.g.
+     * "folder/subfolder/job"). Using these separators verbatim as the build-info name results in
+     * invalid Build Info URLs (404) after publication. This mirrors the legacy Artifactory plugin's
+     * {@code ExtractorUtils.sanitizeBuildName} behavior to keep build names backward-compatible.
+     *
+     * @param buildName - The raw build name (typically derived from JOB_NAME)
+     * @return The sanitized build name, or the original value if it is null
+     */
+    static String sanitizeBuildName(String buildName) {
+        if (buildName == null) {
+            return null;
+        }
+        return StringUtils.replace(
+                StringUtils.replace(buildName, "/", " :: "),
+                "%2F", " :: ");
     }
 
     @SuppressWarnings("HttpUrlsUsage")

--- a/src/test/java/io/jenkins/plugins/jfrog/CliEnvConfiguratorTest.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/CliEnvConfiguratorTest.java
@@ -49,6 +49,32 @@ public class CliEnvConfiguratorTest {
     }
 
     @Test
+    public void configureCliEnvNestedJobNameTest() throws IOException, InterruptedException {
+        // Nested folder jobs expose a JOB_NAME containing folder separators ('/'),
+        // which must be sanitized to ' :: ' to produce valid Build Info URLs.
+        envVars.put("JOB_NAME", "folder/subfolder/buildName");
+        invokeConfigureCliEnv();
+        assertEnv(envVars, JFROG_CLI_BUILD_NAME, "folder :: subfolder :: buildName");
+    }
+
+    @Test
+    public void configureCliEnvEncodedNestedJobNameTest() throws IOException, InterruptedException {
+        // URL-encoded folder separators ('%2F') must also be sanitized to ' :: '.
+        envVars.put("JOB_NAME", "folder%2FbuildName");
+        invokeConfigureCliEnv();
+        assertEnv(envVars, JFROG_CLI_BUILD_NAME, "folder :: buildName");
+    }
+
+    @Test
+    public void configureCliEnvExplicitBuildNameNotSanitizedTest() throws IOException, InterruptedException {
+        // An explicitly provided build name must be preserved as-is (putIfAbsent semantics).
+        envVars.put("JOB_NAME", "folder/buildName");
+        envVars.put(JFROG_CLI_BUILD_NAME, "custom/build/name");
+        invokeConfigureCliEnv();
+        assertEnv(envVars, JFROG_CLI_BUILD_NAME, "custom/build/name");
+    }
+
+    @Test
     public void configEncryptionTest() throws IOException, InterruptedException {
         JFrogCliConfigEncryption configEncryption = new JFrogCliConfigEncryption(envVars);
         assertTrue(configEncryption.shouldEncrypt());


### PR DESCRIPTION
## What

When a Jenkins job lives inside one or more folders, the plugin now sanitizes the default build-info name derived from `JOB_NAME` by replacing folder separators (`/` and its URL-encoded form `%2F`) with `" :: "`.

- `CliEnvConfigurator.configureCliEnv` now sets `JFROG_CLI_BUILD_NAME` to `sanitizeBuildName(JOB_NAME)` instead of the raw `JOB_NAME`.
- Added a `sanitizeBuildName` helper mirroring the legacy Artifactory plugin's `ExtractorUtils.sanitizeBuildName`.
- Only the auto-derived default is sanitized; an explicitly provided `JFROG_CLI_BUILD_NAME` is left untouched (`putIfAbsent` semantics).
- Added unit tests for nested names, `%2F`-encoded names, and the explicit-override case.

Example: a job `demo-folder/nested-job` now publishes as `demo-folder :: nested-job` instead of `demo-folder/nested-job`.

## Why

For nested folder jobs, `JOB_NAME` contains `/` (e.g. `folder/subfolder/job`). Because `/` is a path delimiter in the Build Info REST/UI URL (`/ui/builds/{buildName}/{buildNumber}/...`), the raw name splits into extra path segments, so the generated Build Info link resolves incorrectly and returns **404** after publication.

The legacy Artifactory plugin avoided this by replacing `/` with `" :: "`. This PR restores that backward-compatible behavior so:
- Existing customers keep the exact same build names they had on the legacy plugin (no split/duplicated build history).
- The customer-side workaround (`JFROG_CLI_BUILD_NAME = "${env.JOB_NAME}".replace('/', ' :: ')`) is no longer needed.

`" :: "` contains no path delimiters, so it stays a single, correctly percent-encoded URL segment (the historical `::` encoding bugs were fixed years ago and are not present in current Artifactory, e.g. the reported 7.133.21).

Reported env: 7.133.21 / on-prem.

Backward-compatible condition ported from the Artifactory Jenkins plugin: https://github.com/jfrog/jenkins-artifactory-plugin/blob/master/src/main/java/org/jfrog/hudson/util/ExtractorUtils.java#L525

## Testing

- `mvn test -Dtest=CliEnvConfiguratorTest` — 6/6 pass (3 new).
- Manually verified end-to-end in a local Jenkins (`mvn hpi:run`) with a nested folder freestyle job:
  - Before: `[JFrog Build Info] Build name: demo-folder/nested-job`
  - After: `[JFrog Build Info] Build name: demo-folder :: nested-job`
