### PR TITLE
RTECO-1660 - Added the folder level credential

### DIFF
--- a/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
@@ -34,6 +34,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import static io.jenkins.plugins.jfrog.JfrogInstallation.JFROG_BINARY_PATH;
 import static org.apache.commons.lang3.StringUtils.*;
@@ -45,6 +47,7 @@ import static org.jfrog.build.extractor.BuildInfoExtractorUtils.createMapper;
 @Getter
 @SuppressWarnings("unused")
 public class JfStep extends Step {
+    private static final Logger logger = Logger.getLogger(JfStep.class.getName());
     private static final ObjectMapper mapper = createMapper();
     protected String[] args;
     static final Version MIN_CLI_VERSION_PASSWORD_STDIN = new Version("2.31.3");
@@ -337,6 +340,13 @@ public class JfStep extends Step {
             builder.addMasked("--access-token=" + accessTokenCredentials.getSecret().getPlainText());
         } else {
             Credentials credentials = PluginsUtils.credentialsLookup(credentialsId, lookupContext);
+            // A folder override that points at a deleted/renamed credential resolves to empty here,
+            // which later surfaces as a confusing "unauthorized" failure. Make the cause visible.
+            if (folderOverride != null && credentials == Credentials.EMPTY_CREDENTIALS) {
+                logger.log(Level.WARNING, "Folder-level JFrog credentials override for server '" + jfrogPlatformInstance.getId()
+                        + "' in folder '" + folderOverride.getContext().getFullName() + "' resolved to no credentials (id '"
+                        + credentialsId + "'). The credential may have been deleted or renamed. Check the folder configuration.");
+            }
             builder.add("--user=" + credentials.getUsername());
             addPasswordArgument(builder, credentials, launcher, passwordStdinSupported);
         }

--- a/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import org.jfrog.build.client.Version;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import hudson.*;
+import hudson.model.Item;
 import hudson.model.Job;
 import hudson.model.Run;
 import hudson.model.TaskListener;
@@ -11,6 +12,7 @@ import hudson.util.ArgumentListBuilder;
 import io.jenkins.plugins.jfrog.actions.BuildInfoBuildBadgeAction;
 import io.jenkins.plugins.jfrog.actions.JFrogCliConfigEncryption;
 import io.jenkins.plugins.jfrog.configuration.Credentials;
+import io.jenkins.plugins.jfrog.configuration.FolderCredentialsResolver;
 import io.jenkins.plugins.jfrog.configuration.JFrogPlatformBuilder;
 import io.jenkins.plugins.jfrog.configuration.JFrogPlatformInstance;
 import io.jenkins.plugins.jfrog.models.BuildInfoOutputModel;
@@ -318,12 +320,23 @@ public class JfStep extends Step {
 
     static void addCredentialsArguments(ArgumentListBuilder builder, JFrogPlatformInstance jfrogPlatformInstance, Job<?, ?> job, Launcher.ProcStarter launcher, boolean passwordStdinSupported) {
         String credentialsId = jfrogPlatformInstance.getCredentialsConfig().getCredentialsId();
-        StringCredentials accessTokenCredentials = PluginsUtils.accessTokenCredentialsLookup(credentialsId, job);
+        Item lookupContext = job;
+
+        // Prefer a folder-scoped override for this server ID when the job lives under a folder
+        // that maps the server to different credentials.
+        FolderCredentialsResolver.Resolution folderOverride =
+                FolderCredentialsResolver.resolve(job, jfrogPlatformInstance.getId());
+        if (folderOverride != null) {
+            credentialsId = folderOverride.getCredentialsId();
+            lookupContext = folderOverride.getContext();
+        }
+
+        StringCredentials accessTokenCredentials = PluginsUtils.accessTokenCredentialsLookup(credentialsId, lookupContext);
 
         if (accessTokenCredentials != null) {
             builder.addMasked("--access-token=" + accessTokenCredentials.getSecret().getPlainText());
         } else {
-            Credentials credentials = PluginsUtils.credentialsLookup(credentialsId, job);
+            Credentials credentials = PluginsUtils.credentialsLookup(credentialsId, lookupContext);
             builder.add("--user=" + credentials.getUsername());
             addPasswordArgument(builder, credentials, launcher, passwordStdinSupported);
         }

--- a/src/main/java/io/jenkins/plugins/jfrog/configuration/FolderCredentialsResolver.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/configuration/FolderCredentialsResolver.java
@@ -21,8 +21,30 @@ import java.util.logging.Logger;
 public final class FolderCredentialsResolver {
     private static final Logger logger = Logger.getLogger(FolderCredentialsResolver.class.getName());
 
+    /**
+     * Defensive upper bound on how many levels we walk up the item hierarchy. The folder plugin
+     * should never produce a cycle, but a bound guarantees this can never hang.
+     */
+    private static final int MAX_HOPS = 100;
+
+    /**
+     * Whether the cloudbees-folder plugin is available in this Jenkins. Resolved once at class
+     * load time so we never touch {@link AbstractFolder} bytecode when the plugin is missing.
+     */
+    private static final boolean FOLDER_PLUGIN_PRESENT = isFolderPluginPresent();
+
     private FolderCredentialsResolver() {
         // Utility class
+    }
+
+    private static boolean isFolderPluginPresent() {
+        try {
+            Class.forName("com.cloudbees.hudson.plugins.folder.AbstractFolder");
+            return true;
+        } catch (ClassNotFoundException | LinkageError e) {
+            logger.log(Level.FINE, "cloudbees-folder plugin not available; folder-level JFrog credentials disabled", e);
+            return false;
+        }
     }
 
     /**
@@ -33,12 +55,13 @@ public final class FolderCredentialsResolver {
      * @return the resolved override, or {@code null} if no enclosing folder overrides this server
      */
     public static Resolution resolve(Job<?, ?> job, String serverId) {
-        if (job == null || StringUtils.isBlank(serverId)) {
+        if (!FOLDER_PLUGIN_PRESENT || job == null || StringUtils.isBlank(serverId)) {
             return null;
         }
         try {
             ItemGroup<?> parent = job.getParent();
-            while (parent != null) {
+            int hops = 0;
+            while (parent != null && hops++ < MAX_HOPS) {
                 if (parent instanceof AbstractFolder) {
                     AbstractFolder<?> folder = (AbstractFolder<?>) parent;
                     JFrogFolderProperty property = folder.getProperties().get(JFrogFolderProperty.class);
@@ -57,10 +80,13 @@ public final class FolderCredentialsResolver {
                     break;
                 }
             }
-        } catch (Throwable t) {
-            // The cloudbees-folder plugin might be unavailable at runtime, or the lookup could fail.
-            // In either case we fall back to the globally configured credentials.
-            logger.log(Level.FINE, "Failed to resolve folder-level JFrog credentials for server '" + serverId + "'", t);
+        } catch (LinkageError e) {
+            // The cloudbees-folder plugin became unavailable at runtime; fall back to global creds.
+            logger.log(Level.FINE, "cloudbees-folder plugin unavailable while resolving folder-level JFrog credentials for server '" + serverId + "'", e);
+        } catch (RuntimeException e) {
+            // Anything unexpected (misconfiguration, lookup failure) must be visible to operators,
+            // otherwise the silent fall back to global credentials is hard to diagnose.
+            logger.log(Level.WARNING, "Failed to resolve folder-level JFrog credentials for server '" + serverId + "'; falling back to global credentials", e);
         }
         return null;
     }

--- a/src/main/java/io/jenkins/plugins/jfrog/configuration/FolderCredentialsResolver.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/configuration/FolderCredentialsResolver.java
@@ -17,6 +17,11 @@ import java.util.logging.Logger;
  * JFrog server ID. The nearest enclosing folder that defines an override wins; if no folder
  * overrides the server, {@code null} is returned and the caller falls back to the globally
  * configured credentials.
+ * <p>
+ * This is a stateless utility class, not an instantiable service: every input needed to resolve
+ * an override ({@code job}, {@code serverId}) is passed into {@link #resolve}, so there is no
+ * per-instance state to hold. Static members and a private constructor keep that explicit and
+ * prevent callers from instantiating an object that would carry no state.
  */
 public final class FolderCredentialsResolver {
     private static final Logger logger = Logger.getLogger(FolderCredentialsResolver.class.getName());
@@ -37,12 +42,22 @@ public final class FolderCredentialsResolver {
         // Utility class
     }
 
+    /**
+     * cloudbees-folder is an optional dependency: it may not be installed in a given Jenkins
+     * instance. {@code resolve} below uses {@code instanceof AbstractFolder} and casts to it, and
+     * the JVM resolves those references (triggering class loading) the first time this class's
+     * bytecode runs, not just when the branch is taken. Probing for the class explicitly here,
+     * inside a try/catch, lets us detect a missing plugin gracefully instead of failing with a
+     * {@link LinkageError} the first time {@code resolve} executes.
+     */
     private static boolean isFolderPluginPresent() {
         try {
             Class.forName("com.cloudbees.hudson.plugins.folder.AbstractFolder");
             return true;
         } catch (ClassNotFoundException | LinkageError e) {
-            logger.log(Level.FINE, "cloudbees-folder plugin not available; folder-level JFrog credentials disabled", e);
+            // Expected when cloudbees-folder isn't installed — not an error, so FINE rather than
+            // WARNING; folder-level overrides are simply unavailable and global credentials apply.
+            logger.log(Level.FINE, "cloudbees-folder plugin not available; folder-level JFrog credential overrides are disabled", e);
             return false;
         }
     }
@@ -81,11 +96,16 @@ public final class FolderCredentialsResolver {
                 }
             }
         } catch (LinkageError e) {
-            // The cloudbees-folder plugin became unavailable at runtime; fall back to global creds.
+            // Same "plugin isn't really there" case as isFolderPluginPresent() above (e.g. the
+            // plugin was uninstalled between the class-load check and this call) — expected in a
+            // dynamic Jenkins install, not a bug, so FINE rather than WARNING.
             logger.log(Level.FINE, "cloudbees-folder plugin unavailable while resolving folder-level JFrog credentials for server '" + serverId + "'", e);
         } catch (RuntimeException e) {
-            // Anything unexpected (misconfiguration, lookup failure) must be visible to operators,
-            // otherwise the silent fall back to global credentials is hard to diagnose.
+            // Unlike the case above, this means the plugin IS present but something about the
+            // folder configuration or credential lookup itself failed unexpectedly. That must stay
+            // visible to operators — WARNING, not INFO/FINE — otherwise the silent fall back to
+            // global credentials is hard to diagnose (e.g. builds failing "unauthorized" against
+            // the wrong server with no clue why).
             logger.log(Level.WARNING, "Failed to resolve folder-level JFrog credentials for server '" + serverId + "'; falling back to global credentials", e);
         }
         return null;

--- a/src/main/java/io/jenkins/plugins/jfrog/configuration/FolderCredentialsResolver.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/configuration/FolderCredentialsResolver.java
@@ -1,0 +1,89 @@
+package io.jenkins.plugins.jfrog.configuration;
+
+import com.cloudbees.hudson.plugins.folder.AbstractFolder;
+import hudson.model.Item;
+import hudson.model.ItemGroup;
+import hudson.model.Job;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Resolves folder-level credential overrides for JFrog server IDs.
+ * <p>
+ * Given the job that is about to run a {@code jf} command, this walks up the folder hierarchy
+ * looking for a {@link JFrogFolderProperty} that overrides the credentials for the requested
+ * JFrog server ID. The nearest enclosing folder that defines an override wins; if no folder
+ * overrides the server, {@code null} is returned and the caller falls back to the globally
+ * configured credentials.
+ */
+public final class FolderCredentialsResolver {
+    private static final Logger logger = Logger.getLogger(FolderCredentialsResolver.class.getName());
+
+    private FolderCredentialsResolver() {
+        // Utility class
+    }
+
+    /**
+     * Resolve the folder-scoped credentials override for the given job and JFrog server ID.
+     *
+     * @param job      the job that will run the JFrog CLI command (may be {@code null})
+     * @param serverId the JFrog server ID being configured
+     * @return the resolved override, or {@code null} if no enclosing folder overrides this server
+     */
+    public static Resolution resolve(Job<?, ?> job, String serverId) {
+        if (job == null || StringUtils.isBlank(serverId)) {
+            return null;
+        }
+        try {
+            ItemGroup<?> parent = job.getParent();
+            while (parent != null) {
+                if (parent instanceof AbstractFolder) {
+                    AbstractFolder<?> folder = (AbstractFolder<?>) parent;
+                    JFrogFolderProperty property = folder.getProperties().get(JFrogFolderProperty.class);
+                    if (property != null) {
+                        String credentialsId = property.getCredentialsIdForServer(serverId);
+                        if (StringUtils.isNotBlank(credentialsId)) {
+                            return new Resolution(credentialsId, folder);
+                        }
+                    }
+                }
+                // Move one level up the item hierarchy. The Jenkins root is an ItemGroup but not an
+                // Item, so the loop terminates there.
+                if (parent instanceof Item) {
+                    parent = ((Item) parent).getParent();
+                } else {
+                    break;
+                }
+            }
+        } catch (Throwable t) {
+            // The cloudbees-folder plugin might be unavailable at runtime, or the lookup could fail.
+            // In either case we fall back to the globally configured credentials.
+            logger.log(Level.FINE, "Failed to resolve folder-level JFrog credentials for server '" + serverId + "'", t);
+        }
+        return null;
+    }
+
+    /**
+     * The result of a successful folder-credential resolution: the credentials id to use and the
+     * folder that owns it (used as the lookup context so folder-scoped credentials resolve).
+     */
+    public static final class Resolution {
+        private final String credentialsId;
+        private final Item context;
+
+        Resolution(String credentialsId, Item context) {
+            this.credentialsId = credentialsId;
+            this.context = context;
+        }
+
+        public String getCredentialsId() {
+            return credentialsId;
+        }
+
+        public Item getContext() {
+            return context;
+        }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/jfrog/configuration/FolderServerCredentialsMapping.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/configuration/FolderServerCredentialsMapping.java
@@ -6,6 +6,7 @@ import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
 import hudson.model.Item;
+import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import io.jenkins.plugins.jfrog.plugins.PluginsUtils;
 import jenkins.model.Jenkins;
@@ -15,9 +16,9 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 
 import javax.annotation.Nonnull;
-import java.io.Serializable;
 import java.util.List;
 
+import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.trimToEmpty;
 
 /**
@@ -28,8 +29,7 @@ import static org.apache.commons.lang3.StringUtils.trimToEmpty;
  * override the credentials that were configured globally for a given JFrog server ID,
  * without having to reconfigure the server through the CLI.
  */
-public class FolderServerCredentialsMapping extends AbstractDescribableImpl<FolderServerCredentialsMapping> implements Serializable {
-    private static final long serialVersionUID = 1L;
+public class FolderServerCredentialsMapping extends AbstractDescribableImpl<FolderServerCredentialsMapping> {
 
     private final String serverId;
     private final String credentialsId;
@@ -63,7 +63,7 @@ public class FolderServerCredentialsMapping extends AbstractDescribableImpl<Fold
         @SuppressWarnings("unused")
         public ListBoxModel doFillServerIdItems() {
             ListBoxModel items = new ListBoxModel();
-            items.add("", "");
+            items.add("-- Select a server --", "");
             List<JFrogPlatformInstance> instances = JFrogPlatformBuilder.getJFrogPlatformInstances();
             if (instances != null) {
                 for (JFrogPlatformInstance instance : instances) {
@@ -73,6 +73,28 @@ public class FolderServerCredentialsMapping extends AbstractDescribableImpl<Fold
                 }
             }
             return items;
+        }
+
+        /**
+         * Flag a mapping saved without a server ID, so it is caught in the UI rather than
+         * silently ignored when credentials are resolved at build time.
+         */
+        @SuppressWarnings("unused")
+        public FormValidation doCheckServerId(@QueryParameter String value) {
+            return isBlank(value)
+                    ? FormValidation.error("Select a JFrog server ID for this mapping.")
+                    : FormValidation.ok();
+        }
+
+        /**
+         * Flag a mapping saved without a credential, so it is caught in the UI rather than
+         * silently ignored when credentials are resolved at build time.
+         */
+        @SuppressWarnings("unused")
+        public FormValidation doCheckCredentialsId(@QueryParameter String value) {
+            return isBlank(value)
+                    ? FormValidation.error("Select the credentials to use for this JFrog server ID.")
+                    : FormValidation.ok();
         }
 
         /**

--- a/src/main/java/io/jenkins/plugins/jfrog/configuration/FolderServerCredentialsMapping.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/configuration/FolderServerCredentialsMapping.java
@@ -1,0 +1,99 @@
+package io.jenkins.plugins.jfrog.configuration;
+
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
+import hudson.Extension;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+import hudson.model.Item;
+import hudson.util.ListBoxModel;
+import io.jenkins.plugins.jfrog.plugins.PluginsUtils;
+import jenkins.model.Jenkins;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.AncestorInPath;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+
+import javax.annotation.Nonnull;
+import java.io.Serializable;
+import java.util.List;
+
+import static org.apache.commons.lang3.StringUtils.trimToEmpty;
+
+/**
+ * A single mapping between a globally configured JFrog server ID and a folder-scoped
+ * Jenkins credential that should be used for it.
+ * <p>
+ * These mappings are stored on a {@link JFrogFolderProperty} and let jobs inside a folder
+ * override the credentials that were configured globally for a given JFrog server ID,
+ * without having to reconfigure the server through the CLI.
+ */
+public class FolderServerCredentialsMapping extends AbstractDescribableImpl<FolderServerCredentialsMapping> implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final String serverId;
+    private final String credentialsId;
+
+    @DataBoundConstructor
+    public FolderServerCredentialsMapping(String serverId, String credentialsId) {
+        this.serverId = trimToEmpty(serverId);
+        this.credentialsId = trimToEmpty(credentialsId);
+    }
+
+    public String getServerId() {
+        return serverId;
+    }
+
+    public String getCredentialsId() {
+        return credentialsId;
+    }
+
+    @Extension
+    @Symbol("jfrogServerCredentials")
+    public static class DescriptorImpl extends Descriptor<FolderServerCredentialsMapping> {
+        @Nonnull
+        @Override
+        public String getDisplayName() {
+            return "JFrog server credentials mapping";
+        }
+
+        /**
+         * Populate the dropdown with the JFrog server IDs configured globally.
+         */
+        @SuppressWarnings("unused")
+        public ListBoxModel doFillServerIdItems() {
+            ListBoxModel items = new ListBoxModel();
+            items.add("", "");
+            List<JFrogPlatformInstance> instances = JFrogPlatformBuilder.getJFrogPlatformInstances();
+            if (instances != null) {
+                for (JFrogPlatformInstance instance : instances) {
+                    if (instance != null && instance.getId() != null) {
+                        items.add(instance.getId(), instance.getId());
+                    }
+                }
+            }
+            return items;
+        }
+
+        /**
+         * Populate the credentials dropdown, scoped to the folder that is currently being configured.
+         * This is what makes folder-level credentials selectable for a JFrog server ID.
+         *
+         * @param item          the item (folder) being configured, injected by Stapler
+         * @param credentialsId the currently selected credentials id
+         * @return the list of credentials the user is allowed to select
+         */
+        @SuppressWarnings("unused")
+        public ListBoxModel doFillCredentialsIdItems(@AncestorInPath Item item, @QueryParameter String credentialsId) {
+            StandardListBoxModel result = new StandardListBoxModel();
+            if (item == null) {
+                if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
+                    return result.includeCurrentValue(credentialsId);
+                }
+            } else if (!item.hasPermission(Item.EXTENDED_READ) && !item.hasPermission(CredentialsProvider.USE_ITEM)) {
+                return result.includeCurrentValue(credentialsId);
+            }
+            return PluginsUtils.fillPluginCredentials(item);
+        }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/jfrog/configuration/JFrogFolderProperty.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/configuration/JFrogFolderProperty.java
@@ -27,7 +27,7 @@ import java.util.List;
  */
 public class JFrogFolderProperty extends AbstractFolderProperty<AbstractFolder<?>> {
 
-    private List<FolderServerCredentialsMapping> serverCredentialsMappings;
+    private final List<FolderServerCredentialsMapping> serverCredentialsMappings;
 
     @DataBoundConstructor
     public JFrogFolderProperty(List<FolderServerCredentialsMapping> serverCredentialsMappings) {

--- a/src/main/java/io/jenkins/plugins/jfrog/configuration/JFrogFolderProperty.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/configuration/JFrogFolderProperty.java
@@ -1,0 +1,75 @@
+package io.jenkins.plugins.jfrog.configuration;
+
+import com.cloudbees.hudson.plugins.folder.AbstractFolder;
+import com.cloudbees.hudson.plugins.folder.AbstractFolderProperty;
+import com.cloudbees.hudson.plugins.folder.AbstractFolderPropertyDescriptor;
+import hudson.Extension;
+import org.apache.commons.lang3.StringUtils;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A {@link com.cloudbees.hudson.plugins.folder.Folder Folder}-level property that lets users
+ * override the credentials used for a globally configured JFrog server ID with credentials
+ * scoped to that folder.
+ * <p>
+ * Previously, the only way to change the credentials of a JFrog server ID for a specific set of
+ * jobs was to reconfigure the server manually through the CLI
+ * ({@code jf config edit <server-id> --user <user> --password <password>}). With this property,
+ * a folder can declare, per JFrog server ID, which folder-scoped credential to use. Jobs inside
+ * the folder (or nested sub-folders) then pick up those credentials automatically when the plugin
+ * runs {@code jf c add <server-id>}.
+ */
+public class JFrogFolderProperty extends AbstractFolderProperty<AbstractFolder<?>> {
+
+    private List<FolderServerCredentialsMapping> serverCredentialsMappings;
+
+    @DataBoundConstructor
+    public JFrogFolderProperty(List<FolderServerCredentialsMapping> serverCredentialsMappings) {
+        this.serverCredentialsMappings = serverCredentialsMappings == null
+                ? new ArrayList<>()
+                : new ArrayList<>(serverCredentialsMappings);
+    }
+
+    public List<FolderServerCredentialsMapping> getServerCredentialsMappings() {
+        return serverCredentialsMappings == null
+                ? Collections.emptyList()
+                : Collections.unmodifiableList(serverCredentialsMappings);
+    }
+
+    /**
+     * Return the folder-scoped credentials id configured for the given JFrog server ID, or
+     * {@code null} if this folder does not override credentials for that server.
+     *
+     * @param serverId the JFrog server ID to look up
+     * @return the overriding credentials id, or {@code null} if none is configured
+     */
+    public String getCredentialsIdForServer(String serverId) {
+        if (StringUtils.isBlank(serverId)) {
+            return null;
+        }
+        for (FolderServerCredentialsMapping mapping : getServerCredentialsMappings()) {
+            if (mapping != null
+                    && serverId.equals(mapping.getServerId())
+                    && StringUtils.isNotBlank(mapping.getCredentialsId())) {
+                return mapping.getCredentialsId();
+            }
+        }
+        return null;
+    }
+
+    @Extension(optional = true)
+    @Symbol("jfrogFolderCredentials")
+    public static class DescriptorImpl extends AbstractFolderPropertyDescriptor {
+        @Nonnull
+        @Override
+        public String getDisplayName() {
+            return "JFrog folder-level credentials";
+        }
+    }
+}

--- a/src/main/resources/io/jenkins/plugins/jfrog/configuration/FolderServerCredentialsMapping/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/jfrog/configuration/FolderServerCredentialsMapping/config.jelly
@@ -1,0 +1,11 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
+    <f:entry title="Server ID" field="serverId"
+             description="A JFrog server ID configured under 'Manage Jenkins' > 'System'.">
+        <f:select/>
+    </f:entry>
+    <f:entry title="Credentials" field="credentialsId"
+             description="Folder-scoped credentials to use for the selected JFrog server ID.">
+        <c:select/>
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/io/jenkins/plugins/jfrog/configuration/JFrogFolderProperty/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/jfrog/configuration/JFrogFolderProperty/config.jelly
@@ -1,0 +1,14 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:entry title="JFrog server credentials"
+             description="Override the credentials used for a globally configured JFrog server ID with folder-scoped credentials. Jobs in this folder (and its sub-folders) will use the selected credentials when configuring the JFrog server.">
+        <f:repeatableProperty field="serverCredentialsMappings"
+                              add="${%Add JFrog server credentials}">
+            <f:block>
+                <div align="right">
+                    <f:repeatableDeleteButton/>
+                </div>
+            </f:block>
+        </f:repeatableProperty>
+    </f:entry>
+</j:jelly>

--- a/src/test/java/io/jenkins/plugins/jfrog/JfStepFolderCredentialsTest.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/JfStepFolderCredentialsTest.java
@@ -1,0 +1,89 @@
+package io.jenkins.plugins.jfrog;
+
+import com.cloudbees.hudson.plugins.folder.Folder;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.CredentialsStore;
+import com.cloudbees.plugins.credentials.domains.Domain;
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
+import hudson.Launcher;
+import hudson.model.FreeStyleProject;
+import hudson.util.ArgumentListBuilder;
+import hudson.util.Secret;
+import io.jenkins.plugins.jfrog.configuration.CredentialsConfig;
+import io.jenkins.plugins.jfrog.configuration.FolderServerCredentialsMapping;
+import io.jenkins.plugins.jfrog.configuration.JFrogFolderProperty;
+import io.jenkins.plugins.jfrog.configuration.JFrogPlatformInstance;
+import io.jenkins.plugins.jfrog.jenkins.EnableJenkins;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Verifies that folder-level credential overrides are applied when building jf config arguments.
+ */
+@EnableJenkins
+class JfStepFolderCredentialsTest {
+
+    @Test
+    void addCredentialsArgumentsUsesFolderOverrideInsteadOfGlobal(JenkinsRule r) throws Exception {
+        CredentialsStore rootStore = CredentialsProvider.lookupStores(r.jenkins).iterator().next();
+        rootStore.addCredentials(Domain.global(), new UsernamePasswordCredentialsImpl(
+                CredentialsScope.GLOBAL, "global-cred", null, "global-user", "global-pass"));
+
+        Folder folder = r.jenkins.createProject(Folder.class, "team");
+        CredentialsStore folderStore = CredentialsProvider.lookupStores(folder).iterator().next();
+        folderStore.addCredentials(Domain.global(), new UsernamePasswordCredentialsImpl(
+                CredentialsScope.GLOBAL, "folder-cred", null, "folder-user", "folder-pass"));
+        folder.addProperty(new JFrogFolderProperty(Collections.singletonList(
+                new FolderServerCredentialsMapping("acme", "folder-cred"))));
+
+        FreeStyleProject job = folder.createProject(FreeStyleProject.class, "job");
+        JFrogPlatformInstance instance = new JFrogPlatformInstance(
+                "acme",
+                "https://example.jfrog.io",
+                new CredentialsConfig(Secret.fromString(""), Secret.fromString(""), Secret.fromString(""), "global-cred"),
+                "",
+                "",
+                "");
+
+        ArgumentListBuilder builder = new ArgumentListBuilder();
+        JfStep.addCredentialsArguments(builder, instance, job, mock(Launcher.ProcStarter.class), false);
+
+        assertTrue(
+                builder.toList().contains("--user=folder-user"),
+                "Expected folder override credentials, got: " + builder.toList());
+        assertFalse(
+                builder.toList().contains("--user=global-user"),
+                "Global credentials must not be used when a folder override exists: " + builder.toList());
+    }
+
+    @Test
+    void addCredentialsArgumentsFallsBackToGlobalWhenNoFolderOverride(JenkinsRule r) throws Exception {
+        CredentialsStore rootStore = CredentialsProvider.lookupStores(r.jenkins).iterator().next();
+        rootStore.addCredentials(Domain.global(), new UsernamePasswordCredentialsImpl(
+                CredentialsScope.GLOBAL, "global-cred", null, "global-user", "global-pass"));
+
+        Folder folder = r.jenkins.createProject(Folder.class, "team-no-override");
+        FreeStyleProject job = folder.createProject(FreeStyleProject.class, "job");
+        JFrogPlatformInstance instance = new JFrogPlatformInstance(
+                "acme",
+                "https://example.jfrog.io",
+                new CredentialsConfig(Secret.fromString(""), Secret.fromString(""), Secret.fromString(""), "global-cred"),
+                "",
+                "",
+                "");
+
+        ArgumentListBuilder builder = new ArgumentListBuilder();
+        JfStep.addCredentialsArguments(builder, instance, job, mock(Launcher.ProcStarter.class), false);
+
+        assertTrue(
+                builder.toList().contains("--user=global-user"),
+                "Expected global credentials when no folder override exists, got: " + builder.toList());
+    }
+}

--- a/src/test/java/io/jenkins/plugins/jfrog/JfStepFolderCredentialsTest.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/JfStepFolderCredentialsTest.java
@@ -15,6 +15,7 @@ import io.jenkins.plugins.jfrog.configuration.FolderServerCredentialsMapping;
 import io.jenkins.plugins.jfrog.configuration.JFrogFolderProperty;
 import io.jenkins.plugins.jfrog.configuration.JFrogPlatformInstance;
 import io.jenkins.plugins.jfrog.jenkins.EnableJenkins;
+import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
@@ -85,5 +86,38 @@ class JfStepFolderCredentialsTest {
         assertTrue(
                 builder.toList().contains("--user=global-user"),
                 "Expected global credentials when no folder override exists, got: " + builder.toList());
+    }
+
+    @Test
+    void addCredentialsArgumentsUsesFolderScopedAccessToken(JenkinsRule r) throws Exception {
+        CredentialsStore rootStore = CredentialsProvider.lookupStores(r.jenkins).iterator().next();
+        rootStore.addCredentials(Domain.global(), new UsernamePasswordCredentialsImpl(
+                CredentialsScope.GLOBAL, "global-cred", null, "global-user", "global-pass"));
+
+        Folder folder = r.jenkins.createProject(Folder.class, "team-token");
+        CredentialsStore folderStore = CredentialsProvider.lookupStores(folder).iterator().next();
+        folderStore.addCredentials(Domain.global(), new StringCredentialsImpl(
+                CredentialsScope.GLOBAL, "folder-token", "folder access token", Secret.fromString("secret-token-value")));
+        folder.addProperty(new JFrogFolderProperty(Collections.singletonList(
+                new FolderServerCredentialsMapping("acme", "folder-token"))));
+
+        FreeStyleProject job = folder.createProject(FreeStyleProject.class, "job");
+        JFrogPlatformInstance instance = new JFrogPlatformInstance(
+                "acme",
+                "https://example.jfrog.io",
+                new CredentialsConfig(Secret.fromString(""), Secret.fromString(""), Secret.fromString(""), "global-cred"),
+                "",
+                "",
+                "");
+
+        ArgumentListBuilder builder = new ArgumentListBuilder();
+        JfStep.addCredentialsArguments(builder, instance, job, mock(Launcher.ProcStarter.class), false);
+
+        assertTrue(
+                builder.toList().contains("--access-token=secret-token-value"),
+                "Expected folder-scoped access token to be used, got: " + builder.toList());
+        assertFalse(
+                builder.toList().contains("--user=global-user"),
+                "Global credentials must not be used when a folder access-token override exists: " + builder.toList());
     }
 }

--- a/src/test/java/io/jenkins/plugins/jfrog/configuration/JFrogFolderPropertyTest.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/configuration/JFrogFolderPropertyTest.java
@@ -80,6 +80,23 @@ class JFrogFolderPropertyTest {
     }
 
     @Test
+    void resolveFallsBackToGrandparentFolder(JenkinsRule r) throws Exception {
+        Folder grandparent = r.jenkins.createProject(Folder.class, "grandparent-with-override");
+        grandparent.addProperty(new JFrogFolderProperty(Collections.singletonList(
+                new FolderServerCredentialsMapping("serverA", "grandparent-cred"))));
+        // Neither the parent nor the child override serverA.
+        Folder parent = grandparent.createProject(Folder.class, "parent-without-override");
+        Folder child = parent.createProject(Folder.class, "child-without-override");
+        FreeStyleProject job = child.createProject(FreeStyleProject.class, "job");
+
+        FolderCredentialsResolver.Resolution resolution = FolderCredentialsResolver.resolve(job, "serverA");
+
+        assertNotNull(resolution);
+        assertEquals("grandparent-cred", resolution.getCredentialsId());
+        assertSame(grandparent, resolution.getContext());
+    }
+
+    @Test
     void resolveReturnsNullForUnmappedServer(JenkinsRule r) throws Exception {
         Folder folder = r.jenkins.createProject(Folder.class, "folder-with-other-server");
         folder.addProperty(new JFrogFolderProperty(Collections.singletonList(

--- a/src/test/java/io/jenkins/plugins/jfrog/configuration/JFrogFolderPropertyTest.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/configuration/JFrogFolderPropertyTest.java
@@ -1,0 +1,91 @@
+package io.jenkins.plugins.jfrog.configuration;
+
+import com.cloudbees.hudson.plugins.folder.Folder;
+import hudson.model.FreeStyleProject;
+import io.jenkins.plugins.jfrog.jenkins.EnableJenkins;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Tests for folder-level JFrog credentials support.
+ */
+@EnableJenkins
+class JFrogFolderPropertyTest {
+
+    @Test
+    void getCredentialsIdForServerReturnsConfiguredMapping() {
+        JFrogFolderProperty property = new JFrogFolderProperty(Arrays.asList(
+                new FolderServerCredentialsMapping("serverA", "cred-a"),
+                // A mapping without a credentials id must be ignored.
+                new FolderServerCredentialsMapping("serverB", "")));
+
+        assertEquals("cred-a", property.getCredentialsIdForServer("serverA"));
+        assertNull(property.getCredentialsIdForServer("serverB"));
+        assertNull(property.getCredentialsIdForServer("unknown"));
+        assertNull(property.getCredentialsIdForServer(null));
+    }
+
+    @Test
+    void nullMappingsAreHandledGracefully() {
+        JFrogFolderProperty property = new JFrogFolderProperty(null);
+        assertNull(property.getCredentialsIdForServer("serverA"));
+        assertEquals(Collections.emptyList(), property.getServerCredentialsMappings());
+    }
+
+    @Test
+    void resolveReturnsNullWhenJobIsNotInAFolder(JenkinsRule r) throws Exception {
+        FreeStyleProject job = r.createFreeStyleProject("top-level-job");
+        assertNull(FolderCredentialsResolver.resolve(job, "serverA"));
+    }
+
+    @Test
+    void resolveUsesNearestFolderOverride(JenkinsRule r) throws Exception {
+        Folder parent = r.jenkins.createProject(Folder.class, "parent");
+        parent.addProperty(new JFrogFolderProperty(Collections.singletonList(
+                new FolderServerCredentialsMapping("serverA", "parent-cred"))));
+        Folder child = parent.createProject(Folder.class, "child");
+        child.addProperty(new JFrogFolderProperty(Collections.singletonList(
+                new FolderServerCredentialsMapping("serverA", "child-cred"))));
+        FreeStyleProject job = child.createProject(FreeStyleProject.class, "job");
+
+        FolderCredentialsResolver.Resolution resolution = FolderCredentialsResolver.resolve(job, "serverA");
+
+        assertNotNull(resolution);
+        assertEquals("child-cred", resolution.getCredentialsId());
+        assertSame(child, resolution.getContext());
+    }
+
+    @Test
+    void resolveFallsBackToAncestorFolder(JenkinsRule r) throws Exception {
+        Folder parent = r.jenkins.createProject(Folder.class, "parent-with-override");
+        parent.addProperty(new JFrogFolderProperty(Collections.singletonList(
+                new FolderServerCredentialsMapping("serverA", "parent-cred"))));
+        // Child folder has no JFrog override.
+        Folder child = parent.createProject(Folder.class, "child-without-override");
+        FreeStyleProject job = child.createProject(FreeStyleProject.class, "job");
+
+        FolderCredentialsResolver.Resolution resolution = FolderCredentialsResolver.resolve(job, "serverA");
+
+        assertNotNull(resolution);
+        assertEquals("parent-cred", resolution.getCredentialsId());
+        assertSame(parent, resolution.getContext());
+    }
+
+    @Test
+    void resolveReturnsNullForUnmappedServer(JenkinsRule r) throws Exception {
+        Folder folder = r.jenkins.createProject(Folder.class, "folder-with-other-server");
+        folder.addProperty(new JFrogFolderProperty(Collections.singletonList(
+                new FolderServerCredentialsMapping("serverA", "cred-a"))));
+        FreeStyleProject job = folder.createProject(FreeStyleProject.class, "job");
+
+        assertNull(FolderCredentialsResolver.resolve(job, "serverB"));
+    }
+}


### PR DESCRIPTION
**Summary**
Adds folder-level credential overrides for globally configured JFrog server IDs (RTECO-1660).
Introduces a JFrogFolderProperty so folders can map a server ID to folder-scoped Jenkins credentials, without reconfiguring the server via jf config edit.
Resolves credentials by walking up the folder hierarchy; the nearest enclosing folder with an override wins, otherwise global credentials are used.
**Changes**
JFrogFolderProperty + jelly UI for configuring server → credentials mappings on folders
FolderServerCredentialsMapping for individual mappings (server ID + credentials ID)
FolderCredentialsResolver to resolve the nearest folder override for a job
Unit tests covering mapping lookup, nearest-folder precedence, ancestor fallback, and unmapped servers


**Before:**
Below is the screenshot without this feature, there is no option to select credential at user level:
<img width="1728" height="946" alt="Screenshot 2026-08-17 at 9 04 03 AM" src="https://github.com/user-attachments/assets/d6041a02-c592-4e61-85f1-7718140e4fea" />


**After:**
Adding screenshot of having options at folder level to select the credentials.
<img width="1728" height="989" alt="Screenshot 2026-08-12 at 4 04 11 PM" src="https://github.com/user-attachments/assets/0940dd3c-28fc-45e9-be64-1fa383ce8e44" />

Once a credential is selected at folder level as shown in above screenshot, then that credentials are being used successfully in the job/script.
<img width="1728" height="926" alt="Screenshot 2026-08-12 at 4 01 31 PM" src="https://github.com/user-attachments/assets/e5a07596-5b37-4b36-a021-c24674ed9cd4" />

**2nd Example for selecting different user (secondUser):**

<img width="1728" height="962" alt="Screenshot 2026-08-17 at 9 20 26 AM" src="https://github.com/user-attachments/assets/398548dc-1b24-4a78-9abe-54eeca66dba6" />

After selecting secondUser, that user credential is being used in pipeline in that folder:
<img width="1728" height="940" alt="secondUser" src="https://github.com/user-attachments/assets/faa47c4b-d18b-4f4c-b49d-fc6df3ff96bf" />
