### PR TITLE
RTECO-1658 - Fix incorrect quoting of CLI arguments containing spaces

### DIFF
--- a/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
@@ -8,6 +8,7 @@ import hudson.model.Job;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.util.ArgumentListBuilder;
+import hudson.util.QuotedStringTokenizer;
 import io.jenkins.plugins.jfrog.actions.BuildInfoBuildBadgeAction;
 import io.jenkins.plugins.jfrog.actions.JFrogCliConfigEncryption;
 import io.jenkins.plugins.jfrog.configuration.Credentials;
@@ -54,7 +55,7 @@ public class JfStep extends Step {
             this.args = ((List<String>) args).toArray(String[]::new);
             return;
         }
-        this.args = split(args.toString());
+        this.args = QuotedStringTokenizer.tokenize(args.toString());
     }
 
     /**

--- a/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
@@ -8,7 +8,6 @@ import hudson.model.Job;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.util.ArgumentListBuilder;
-import hudson.util.QuotedStringTokenizer;
 import io.jenkins.plugins.jfrog.actions.BuildInfoBuildBadgeAction;
 import io.jenkins.plugins.jfrog.actions.JFrogCliConfigEncryption;
 import io.jenkins.plugins.jfrog.configuration.Credentials;
@@ -55,7 +54,7 @@ public class JfStep extends Step {
             this.args = ((List<String>) args).toArray(String[]::new);
             return;
         }
-        this.args = QuotedStringTokenizer.tokenize(args.toString());
+        this.args = Utils.splitCliArgs(args.toString());
     }
 
     /**

--- a/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
@@ -54,7 +54,7 @@ public class JfStep extends Step {
             this.args = ((List<String>) args).toArray(String[]::new);
             return;
         }
-        this.args = Utils.splitCliArgs(args.toString());
+        this.args = Utils.tokenizeArgs(args.toString());
     }
 
     /**

--- a/src/main/java/io/jenkins/plugins/jfrog/JfrogBuilder.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfrogBuilder.java
@@ -13,6 +13,7 @@ import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
 import hudson.util.ArgumentListBuilder;
 import hudson.util.ListBoxModel;
+import hudson.util.QuotedStringTokenizer;
 import io.jenkins.plugins.jfrog.actions.JFrogCliConfigEncryption;
 import lombok.Getter;
 import org.apache.commons.io.FilenameUtils;
@@ -30,7 +31,6 @@ import java.util.List;
 
 import static io.jenkins.plugins.jfrog.JfStep.*;
 import static io.jenkins.plugins.jfrog.JfrogInstallation.JFROG_BINARY_PATH;
-import static org.apache.commons.lang3.StringUtils.split;
 
 /**
  * Builder for executing JFrog CLI commands in Freestyle jobs.
@@ -115,7 +115,7 @@ public class JfrogBuilder extends Builder {
         }
         
         // Parse the command and remove the 'jf' or 'jfrog' prefix
-        String[] fullArgs = split(trimmedCommand);
+        String[] fullArgs = QuotedStringTokenizer.tokenize(trimmedCommand);
         String[] args;
         if (fullArgs.length > 0 && (fullArgs[0].equals("jf") || fullArgs[0].equals("jfrog"))) {
             // Remove the 'jf' or 'jfrog' prefix since we add it back when building the command

--- a/src/main/java/io/jenkins/plugins/jfrog/JfrogBuilder.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfrogBuilder.java
@@ -114,7 +114,7 @@ public class JfrogBuilder extends Builder {
         }
         
         // Parse the command and remove the 'jf' or 'jfrog' prefix
-        String[] fullArgs = Utils.splitCliArgs(trimmedCommand);
+        String[] fullArgs = Utils.tokenizeArgs(trimmedCommand);
         String[] args;
         if (fullArgs.length > 0 && (fullArgs[0].equals("jf") || fullArgs[0].equals("jfrog"))) {
             // Remove the 'jf' or 'jfrog' prefix since we add it back when building the command

--- a/src/main/java/io/jenkins/plugins/jfrog/JfrogBuilder.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfrogBuilder.java
@@ -13,7 +13,6 @@ import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
 import hudson.util.ArgumentListBuilder;
 import hudson.util.ListBoxModel;
-import hudson.util.QuotedStringTokenizer;
 import io.jenkins.plugins.jfrog.actions.JFrogCliConfigEncryption;
 import lombok.Getter;
 import org.apache.commons.io.FilenameUtils;
@@ -115,7 +114,7 @@ public class JfrogBuilder extends Builder {
         }
         
         // Parse the command and remove the 'jf' or 'jfrog' prefix
-        String[] fullArgs = QuotedStringTokenizer.tokenize(trimmedCommand);
+        String[] fullArgs = Utils.splitCliArgs(trimmedCommand);
         String[] args;
         if (fullArgs.length > 0 && (fullArgs[0].equals("jf") || fullArgs[0].equals("jfrog"))) {
             // Remove the 'jf' or 'jfrog' prefix since we add it back when building the command

--- a/src/main/java/io/jenkins/plugins/jfrog/Utils.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/Utils.java
@@ -10,6 +10,8 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import java.io.IOException;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
 
 import static io.jenkins.plugins.jfrog.JfrogInstallation.JFROG_BINARY_PATH;
 
@@ -86,5 +88,62 @@ public class Utils {
 
     public static FilePath createAndGetJfrogCliHomeTempDir(final FilePath ws, String buildNumber) throws IOException, InterruptedException {
         return createAndGetTempDir(ws).child(buildNumber).child(".jfrog");
+    }
+
+    /**
+     * Split a user-provided JFrog CLI command string into arguments.
+     * <p>
+     * Double quotes group a value that contains whitespace, and the grouping quotes themselves are
+     * removed, so {@code -Dsonar.projectName="C7 CMS"} becomes the single argument
+     * {@code -Dsonar.projectName=C7 CMS}. Every other character is kept verbatim.
+     * <p>
+     * Notably, no escape processing is performed:
+     * <ul>
+     *     <li>Backslashes are literal, so Windows paths such as {@code C:\Users\foo\} and
+     *     {@code \\server\share} reach the CLI unchanged. Arguments are handed to the process
+     *     directly rather than through a shell, so nothing downstream would re-interpret them.</li>
+     *     <li>Single quotes are literal, so values containing apostrophes such as
+     *     {@code -Dmsg=don't} are not mangled. Consequently single quotes do not group.</li>
+     * </ul>
+     * The trade-off is that a literal double quote cannot be embedded in a value; that was equally
+     * true before this method existed.
+     *
+     * @param command The raw command string as entered by the user
+     * @return The parsed arguments, never null
+     */
+    public static String[] splitCliArgs(String command) {
+        List<String> args = new ArrayList<>();
+        StringBuilder currentArg = new StringBuilder();
+        // Tracked separately from currentArg's length so that an explicitly empty quoted value,
+        // such as --foo="", is preserved as an argument instead of being dropped.
+        boolean inArg = false;
+        boolean inQuotes = false;
+
+        for (int i = 0; i < command.length(); i++) {
+            char c = command.charAt(i);
+            if (inQuotes) {
+                if (c == '"') {
+                    inQuotes = false;
+                } else {
+                    currentArg.append(c);
+                }
+            } else if (c == '"') {
+                inQuotes = true;
+                inArg = true;
+            } else if (Character.isWhitespace(c)) {
+                if (inArg) {
+                    args.add(currentArg.toString());
+                    currentArg.setLength(0);
+                    inArg = false;
+                }
+            } else {
+                currentArg.append(c);
+                inArg = true;
+            }
+        }
+        if (inArg) {
+            args.add(currentArg.toString());
+        }
+        return args.toArray(new String[0]);
     }
 }

--- a/src/main/java/io/jenkins/plugins/jfrog/Utils.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/Utils.java
@@ -91,7 +91,7 @@ public class Utils {
     }
 
     /**
-     * Split a user-provided JFrog CLI command string into arguments.
+     * Tokenize a user-provided JFrog CLI command string into arguments.
      * <p>
      * Double quotes group a value that contains whitespace, and the grouping quotes themselves are
      * removed, so {@code -Dsonar.projectName="C7 CMS"} becomes the single argument
@@ -111,12 +111,12 @@ public class Utils {
      * @param command The raw command string as entered by the user
      * @return The parsed arguments, never null
      */
-    public static String[] splitCliArgs(String command) {
-        List<String> args = new ArrayList<>();
-        StringBuilder currentArg = new StringBuilder();
-        // Tracked separately from currentArg's length so that an explicitly empty quoted value,
+    public static String[] tokenizeArgs(String command) {
+        List<String> tokens = new ArrayList<>();
+        StringBuilder token = new StringBuilder();
+        // Tracked separately from token's length so that an explicitly empty quoted value,
         // such as --foo="", is preserved as an argument instead of being dropped.
-        boolean inArg = false;
+        boolean tokenStarted = false;
         boolean inQuotes = false;
 
         for (int i = 0; i < command.length(); i++) {
@@ -125,25 +125,25 @@ public class Utils {
                 if (c == '"') {
                     inQuotes = false;
                 } else {
-                    currentArg.append(c);
+                    token.append(c);
                 }
             } else if (c == '"') {
                 inQuotes = true;
-                inArg = true;
+                tokenStarted = true;
             } else if (Character.isWhitespace(c)) {
-                if (inArg) {
-                    args.add(currentArg.toString());
-                    currentArg.setLength(0);
-                    inArg = false;
+                if (tokenStarted) {
+                    tokens.add(token.toString());
+                    token.setLength(0);
+                    tokenStarted = false;
                 }
             } else {
-                currentArg.append(c);
-                inArg = true;
+                token.append(c);
+                tokenStarted = true;
             }
         }
-        if (inArg) {
-            args.add(currentArg.toString());
+        if (tokenStarted) {
+            tokens.add(token.toString());
         }
-        return args.toArray(new String[0]);
+        return tokens.toArray(new String[0]);
     }
 }

--- a/src/test/java/io/jenkins/plugins/jfrog/JfStepTest.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/JfStepTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.stream.Stream;
 
 import static io.jenkins.plugins.jfrog.JfStep.Execution.getJFrogCLIPath;
@@ -29,6 +30,30 @@ import static org.mockito.Mockito.*;
  * @author yahavi
  **/
 public class JfStepTest {
+
+    @ParameterizedTest
+    @MethodSource("quotedArgsProvider")
+    void quotedArgsAreNotSplitOnInternalSpaces(String rawArgs, String[] expectedArgs) {
+        JfStep step = new JfStep(rawArgs);
+        assertArrayEquals(expectedArgs, step.getArgs());
+    }
+
+    private static Stream<Arguments> quotedArgsProvider() {
+        return Stream.of(
+                // Double-quoted value containing a space must stay as a single argument.
+                Arguments.of("rt mvn -Dsonar.projectName=\"C7 CMS\"", new String[]{"rt", "mvn", "-Dsonar.projectName=C7 CMS"}),
+                // Single-quoted value containing a space must stay as a single argument.
+                Arguments.of("rt mvn -Dsonar.projectName='C7 CMS'", new String[]{"rt", "mvn", "-Dsonar.projectName=C7 CMS"}),
+                // Unquoted args are split on whitespace as before.
+                Arguments.of("rt ping", new String[]{"rt", "ping"})
+        );
+    }
+
+    @Test
+    void listArgsArePassedThroughVerbatim() {
+        JfStep step = new JfStep(Arrays.asList("rt", "mvn", "-Dsonar.projectName=C7 CMS"));
+        assertArrayEquals(new String[]{"rt", "mvn", "-Dsonar.projectName=C7 CMS"}, step.getArgs());
+    }
 
     @ParameterizedTest
     @MethodSource("jfrogCLIPathProvider")

--- a/src/test/java/io/jenkins/plugins/jfrog/JfStepTest.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/JfStepTest.java
@@ -42,8 +42,8 @@ public class JfStepTest {
         return Stream.of(
                 // Double-quoted value containing a space must stay as a single argument.
                 Arguments.of("rt mvn -Dsonar.projectName=\"C7 CMS\"", new String[]{"rt", "mvn", "-Dsonar.projectName=C7 CMS"}),
-                // Single-quoted value containing a space must stay as a single argument.
-                Arguments.of("rt mvn -Dsonar.projectName='C7 CMS'", new String[]{"rt", "mvn", "-Dsonar.projectName=C7 CMS"}),
+                // Single quotes are literal and do not group, so an apostrophe is never swallowed.
+                Arguments.of("rt mvn -Dmsg=don't", new String[]{"rt", "mvn", "-Dmsg=don't"}),
                 // Unquoted args are split on whitespace as before.
                 Arguments.of("rt ping", new String[]{"rt", "ping"})
         );

--- a/src/test/java/io/jenkins/plugins/jfrog/UtilsSplitCliArgsTest.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/UtilsSplitCliArgsTest.java
@@ -9,11 +9,11 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.stream.Stream;
 
-import static io.jenkins.plugins.jfrog.Utils.splitCliArgs;
+import static io.jenkins.plugins.jfrog.Utils.tokenizeArgs;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 /**
- * Tests for {@link Utils#splitCliArgs(String)}.
+ * Tests for {@link Utils#tokenizeArgs(String)}.
  * <p>
  * Double quotes group values containing whitespace and are stripped; nothing else is interpreted.
  * The cases below pin down the two characters that a shell-style tokenizer would otherwise consume:
@@ -25,7 +25,7 @@ public class UtilsSplitCliArgsTest {
     @ParameterizedTest
     @MethodSource("quotingProvider")
     void groupsQuotedValuesAndStripsGroupingQuotes(String command, String[] expected) {
-        assertArrayEquals(expected, splitCliArgs(command));
+        assertArrayEquals(expected, tokenizeArgs(command));
     }
 
     private static Stream<Arguments> quotingProvider() {
@@ -50,7 +50,7 @@ public class UtilsSplitCliArgsTest {
     @ParameterizedTest
     @MethodSource("literalCharactersProvider")
     void keepsBackslashesAndApostrophesLiteral(String command, String[] expected) {
-        assertArrayEquals(expected, splitCliArgs(command));
+        assertArrayEquals(expected, tokenizeArgs(command));
     }
 
     private static Stream<Arguments> literalCharactersProvider() {
@@ -82,7 +82,7 @@ public class UtilsSplitCliArgsTest {
     @ParameterizedTest
     @MethodSource("whitespaceProvider")
     void treatsAllWhitespaceAsASeparator(String command, String[] expected) {
-        assertArrayEquals(expected, splitCliArgs(command));
+        assertArrayEquals(expected, tokenizeArgs(command));
     }
 
     private static Stream<Arguments> whitespaceProvider() {
@@ -107,7 +107,7 @@ public class UtilsSplitCliArgsTest {
     @ParameterizedTest
     @MethodSource("unquotedCommandsProvider")
     void unquotedCommandsTokenizeExactlyAsPlainWhitespaceSplitting(String command) {
-        assertArrayEquals(StringUtils.split(command), splitCliArgs(command),
+        assertArrayEquals(StringUtils.split(command), tokenizeArgs(command),
                 "tokenizing changed for an unquoted command: " + command);
     }
 
@@ -156,7 +156,7 @@ public class UtilsSplitCliArgsTest {
     @Test
     void quotedValueIsReQuotedForWindows() {
         ArgumentListBuilder builder = new ArgumentListBuilder();
-        builder.add("jf.exe").add(splitCliArgs("rt mvn -Dsonar.projectName=\"C7 CMS\""));
+        builder.add("jf.exe").add(tokenizeArgs("rt mvn -Dsonar.projectName=\"C7 CMS\""));
 
         assertArrayEquals(
                 new String[]{"cmd.exe", "/C", "\"jf.exe", "rt", "mvn", "\"-Dsonar.projectName=C7 CMS\"",

--- a/src/test/java/io/jenkins/plugins/jfrog/UtilsSplitCliArgsTest.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/UtilsSplitCliArgsTest.java
@@ -1,0 +1,166 @@
+package io.jenkins.plugins.jfrog;
+
+import hudson.util.ArgumentListBuilder;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static io.jenkins.plugins.jfrog.Utils.splitCliArgs;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+/**
+ * Tests for {@link Utils#splitCliArgs(String)}.
+ * <p>
+ * Double quotes group values containing whitespace and are stripped; nothing else is interpreted.
+ * The cases below pin down the two characters that a shell-style tokenizer would otherwise consume:
+ * the backslash and the apostrophe. Both must stay literal, because the arguments are passed
+ * straight to the process and are never re-parsed by a shell.
+ */
+public class UtilsSplitCliArgsTest {
+
+    @ParameterizedTest
+    @MethodSource("quotingProvider")
+    void groupsQuotedValuesAndStripsGroupingQuotes(String command, String[] expected) {
+        assertArrayEquals(expected, splitCliArgs(command));
+    }
+
+    private static Stream<Arguments> quotingProvider() {
+        return Stream.of(
+                // The reported bug: a quoted value containing a space is a single argument.
+                Arguments.of("rt mvn -Dsonar.projectName=\"C7 CMS\"",
+                        new String[]{"rt", "mvn", "-Dsonar.projectName=C7 CMS"}),
+                Arguments.of("rt bp \"My Build\" 12",
+                        new String[]{"rt", "bp", "My Build", "12"}),
+                Arguments.of("rt upload a.jar repo/ --target-props=\"k1=v 1;k2=v 2\"",
+                        new String[]{"rt", "upload", "a.jar", "repo/", "--target-props=k1=v 1;k2=v 2"}),
+                // Quotes in the middle of an argument still group, and are removed.
+                Arguments.of("-Dp=a\"b c\"d", new String[]{"-Dp=ab cd"}),
+                // An explicitly empty quoted value is preserved as an argument.
+                Arguments.of("--foo=\"\"", new String[]{"--foo="}),
+                // Unquoted commands behave exactly as they did before.
+                Arguments.of("rt ping", new String[]{"rt", "ping"}),
+                Arguments.of("rt upload *.jar repo/", new String[]{"rt", "upload", "*.jar", "repo/"})
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("literalCharactersProvider")
+    void keepsBackslashesAndApostrophesLiteral(String command, String[] expected) {
+        assertArrayEquals(expected, splitCliArgs(command));
+    }
+
+    private static Stream<Arguments> literalCharactersProvider() {
+        return Stream.of(
+                // Windows paths, including a trailing backslash, survive untouched.
+                Arguments.of("-Dpath=C:\\Users\\foo", new String[]{"-Dpath=C:\\Users\\foo"}),
+                Arguments.of("-Dpath=C:\\Users\\foo\\", new String[]{"-Dpath=C:\\Users\\foo\\"}),
+                // Consecutive backslashes are not collapsed (compare JENKINS-2584).
+                Arguments.of("-Dpath=C:\\\\Users\\\\foo", new String[]{"-Dpath=C:\\\\Users\\\\foo"}),
+                Arguments.of("rt upload \\\\server\\share\\f.jar repo/",
+                        new String[]{"rt", "upload", "\\\\server\\share\\f.jar", "repo/"}),
+                // A quoted Windows path keeps both its space and its trailing backslash.
+                Arguments.of("rt upload d.txt \"C:\\Users\\my dir\\\" --flat=true",
+                        new String[]{"rt", "upload", "d.txt", "C:\\Users\\my dir\\", "--flat=true"}),
+                // Backslashes used by --regexp and --exclusions patterns are not escapes.
+                Arguments.of("rt upload (.*)\\.jar repo/{1} --regexp=true",
+                        new String[]{"rt", "upload", "(.*)\\.jar", "repo/{1}", "--regexp=true"}),
+                // Apostrophes are literal and must not swallow the following argument.
+                Arguments.of("-Dmsg=don't --flat=true", new String[]{"-Dmsg=don't", "--flat=true"}),
+                Arguments.of("rt upload it's.txt repo/", new String[]{"rt", "upload", "it's.txt", "repo/"}),
+                Arguments.of("-Ddesc=Bob's build", new String[]{"-Ddesc=Bob's", "build"}),
+                // Single quotes therefore do not group.
+                Arguments.of("-Ddesc='C7 CMS'", new String[]{"-Ddesc='C7", "CMS'"}),
+                // An apostrophe inside a double-quoted value is kept as-is.
+                Arguments.of("-Ddesc=\"it's here\"", new String[]{"-Ddesc=it's here"})
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("whitespaceProvider")
+    void treatsAllWhitespaceAsASeparator(String command, String[] expected) {
+        assertArrayEquals(expected, splitCliArgs(command));
+    }
+
+    private static Stream<Arguments> whitespaceProvider() {
+        return Stream.of(
+                Arguments.of("rt\tping\tfoo", new String[]{"rt", "ping", "foo"}),
+                // Freestyle jobs use a textarea, so commands may span lines.
+                Arguments.of("rt upload\ndummy.txt repo/", new String[]{"rt", "upload", "dummy.txt", "repo/"}),
+                Arguments.of("rt    ping", new String[]{"rt", "ping"}),
+                Arguments.of("   rt ping   ", new String[]{"rt", "ping"}),
+                Arguments.of("", new String[]{}),
+                Arguments.of("   ", new String[]{})
+        );
+    }
+
+    /**
+     * Commands that contain no double quote must be tokenized exactly as the previous
+     * implementation (StringUtils.split) tokenized them. Without a double quote the parser never
+     * enters its quoted state, so it only splits on whitespace and copies every other character
+     * verbatim, which is what plain whitespace splitting did. This guarantees that adding quote
+     * support cannot change the behaviour of any existing unquoted command, for any CLI subcommand.
+     */
+    @ParameterizedTest
+    @MethodSource("unquotedCommandsProvider")
+    void unquotedCommandsTokenizeExactlyAsPlainWhitespaceSplitting(String command) {
+        assertArrayEquals(StringUtils.split(command), splitCliArgs(command),
+                "tokenizing changed for an unquoted command: " + command);
+    }
+
+    private static Stream<String> unquotedCommandsProvider() {
+        return Stream.of(
+                // Generic and configuration commands
+                "rt ping", "c show", "-v",
+                "c add my-server --url=https://x.jfrog.io --interactive=false",
+                // Artifactory file operations
+                "rt upload dummy.txt repo/", "rt u target/*.jar libs-release-local/",
+                "rt download repo/path/ out/", "rt copy repo-a/x.jar repo-b/",
+                "rt move repo-a/x.jar repo-b/", "rt delete repo/old/ --quiet",
+                "rt search repo/*.jar", "rt set-props repo/a.jar key=value",
+                "rt upload (.*)\\.jar repo/{1} --regexp=true",
+                "rt upload . repo/ --exclusions=*.txt;*.md",
+                "rt upload a.jar repo/ --target-props=k1=v1;k2=v2",
+                "rt upload --spec=s.json --spec-vars=key1=val1;key2=val2",
+                "rt upload a.jar repo/ --build-name=my-build --build-number=42",
+                "rt bp my-build 42", "rt bpr my-build 42 target-repo",
+                // Package manager commands
+                "mvn clean install -DskipTests",
+                "mvn clean install -Dsonar.host.url=http://sonar:9000",
+                "gradle clean artifactoryPublish", "npm install", "npm publish",
+                "nuget restore sln.sln", "dotnet restore", "go build ./...",
+                "docker push my-image:latest", "helm push chart.tgz repo",
+                // Security commands
+                "audit --licenses --format=json", "scan a.jar", "xr scan --spec=s.json",
+                "ds rbc release-bundle 1.0.0 --spec=s.json",
+                "rt curl -XGET /api/system/ping",
+                // Windows paths without quotes, including a trailing and a doubled backslash
+                "rt upload C:\\build\\out\\a.jar repo/", "rt upload C:\\build\\out\\ repo/",
+                "rt upload \\\\server\\share\\a.jar repo/", "rt upload C:\\\\build\\\\a.jar repo/",
+                // Apostrophes without quotes
+                "rt upload it's.txt repo/", "rt bp bob's-build 42",
+                "rt upload a.jar repo/ --target-props=desc=don't",
+                // Unusual whitespace
+                "rt\tping", "rt   ping", "  rt ping  "
+        );
+    }
+
+    /**
+     * A quoted value containing a space is re-quoted by {@link ArgumentListBuilder#toWindowsCommand()}
+     * before it is handed to cmd.exe. This pins the resulting command line so that a change in the
+     * re-quoting behaviour is noticed here rather than on a Windows agent.
+     */
+    @Test
+    void quotedValueIsReQuotedForWindows() {
+        ArgumentListBuilder builder = new ArgumentListBuilder();
+        builder.add("jf.exe").add(splitCliArgs("rt mvn -Dsonar.projectName=\"C7 CMS\""));
+
+        assertArrayEquals(
+                new String[]{"cmd.exe", "/C", "\"jf.exe", "rt", "mvn", "\"-Dsonar.projectName=C7 CMS\"",
+                        "&&", "exit", "%%ERRORLEVEL%%\""},
+                builder.toWindowsCommand().toCommandArray());
+    }
+}


### PR DESCRIPTION
## Summary

- Replace `StringUtils.split` with a new `Utils.tokenizeArgs` helper when parsing
  user-supplied CLI argument strings in `JfStep` and `JfrogBuilder`
- `StringUtils.split` breaks on any whitespace, ignoring quotes — an argument like
  `-Dsonar.projectName="C7 CMS"` was split into two broken tokens
  (`-Dsonar.projectName="C7` and `CMS"`), causing Maven/Sonar execution failures
- `Utils.tokenizeArgs` respects double-quoted substrings and strips the surrounding
  quotes, correctly producing a single token: `-Dsonar.projectName=C7 CMS`

## Why not `hudson.util.QuotedStringTokenizer`?

`QuotedStringTokenizer` treats `\` as an escape character and collapses `\\` into
`\` (JENKINS-2584). That would silently mangle Windows paths such as
`C:\Users\foo\` and `\\server\share`. The custom implementation keeps backslashes
literal; arguments are handed to the process directly rather than through a shell,
so nothing downstream re-interprets them.

## Behaviour

| Input | Old (`StringUtils.split`) | New (`tokenizeArgs`) |
|---|---|---|
| `mvn deploy -Dname="C7 CMS"` | `[mvn, deploy, -Dname="C7, CMS"]` ✗ | `[mvn, deploy, -Dname=C7 CMS]` ✓ |
| `C:\Users\foo` | `[C:\Users\foo]` ✓ | `[C:\Users\foo]` ✓ |
| `\\server\share` | `[\\server\share]` ✓ | `[\\server\share]` ✓ |
| `-Dmsg=don't` | `[-Dmsg=don't]` ✓ | `[-Dmsg=don't]` ✓ |