### PR TITLE
RTECO-1774 - Add support for automatic URL-decoding of Maven property values in JFrog CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,25 @@ environment {
 }
 ```
 
+### Decoding URL-encoded Maven property values
+
+If your pipeline passes URL-encoded values as `-D` Maven system properties (e.g., migrating from the Jenkins Artifactory Plugin where values were URL-encoded), you can enable automatic URL-decoding before the values are passed to JFrog CLI:
+
+```groovy
+environment {
+    JFROG_CLI_DECODE_PROPS = "true"
+}
+```
+
+With this enabled, URL-encoded property values are decoded before being sent to Artifactory:
+
+| Input to pipeline | Stored in Artifactory |
+|---|---|
+| `-Ddeploy.scm.location=https%3A%2F%2F...` | `https://...` |
+| `-Ddeploy.scm.branch=feature%2F26.08` | `feature/26.08` |
+
+Without this variable, values are passed to JFrog CLI as-is (default behavior).
+
 ### Using multiple JFrog Platform instances
 
 If you have multiple JFrog Platform instances configured, you can use the `–-server-id` command option with

--- a/README.md
+++ b/README.md
@@ -220,7 +220,12 @@ With this enabled, URL-encoded property values are decoded before being sent to 
 | `-Ddeploy.scm.location=https%3A%2F%2F...` | `https://...` |
 | `-Ddeploy.scm.branch=feature%2F26.08` | `feature/26.08` |
 
-Without this variable, values are passed to JFrog CLI as-is (default behavior).
+Notes:
+
+- Decoding applies only to the `jf mvn` command, and only to arguments in the `-D<key>=<value>` form. All other
+  commands and arguments are always passed to JFrog CLI unchanged.
+- Values that are not valid percent-encoded strings (for example `-Dkey=100%`) are left as they are.
+- Without this variable, values are passed to JFrog CLI as-is (default behavior).
 
 ### Using multiple JFrog Platform instances
 

--- a/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
@@ -48,6 +48,11 @@ public class JfStep extends Step {
     private static final ObjectMapper mapper = createMapper();
     protected String[] args;
     static final Version MIN_CLI_VERSION_PASSWORD_STDIN = new Version("2.31.3");
+    /**
+     * When set to "true" (case-insensitive), URL-encoded values of -D arguments of the 'jf mvn' command are decoded
+     * before being passed to the JFrog CLI. See {@link Execution#decodeDPropertyValues}.
+     */
+    static final String JFROG_CLI_DECODE_PROPS = "JFROG_CLI_DECODE_PROPS";
 
     @DataBoundConstructor
     public JfStep(Object args) {
@@ -121,8 +126,7 @@ public class JfStep extends Step {
             String jfrogBinaryPath = getJFrogCLIPath(env, isWindows);
             boolean passwordStdinSupported = isPasswordStdinEnabled(workspace, env, launcher, jfrogBinaryPath);
 
-            String[] processedArgs = "true".equals(env.get("JFROG_CLI_DECODE_PROPS")) ? decodeDPropertyValues(args) : args;
-            builder.add(jfrogBinaryPath).add(processedArgs);
+            builder.add(jfrogBinaryPath).add(shouldDecodeProps(env, args) ? decodeDPropertyValues(args) : args);
             if (isWindows) {
                 builder = builder.toWindowsCommand();
             }
@@ -146,11 +150,27 @@ public class JfStep extends Step {
         }
 
         /**
+         * Whether the -D property values of this command should be URL-decoded.
+         * Requires the {@link JfStep#JFROG_CLI_DECODE_PROPS} environment variable to be set to "true", and applies
+         * only to the 'jf mvn' command - the Maven extractor is the one attaching these values as artifact properties.
+         *
+         * @param env  - Job's environment variables
+         * @param args - The 'jf' command arguments
+         * @return true if the -D property values should be decoded.
+         */
+        static boolean shouldDecodeProps(EnvVars env, String[] args) {
+            return Boolean.parseBoolean(env.get(JFROG_CLI_DECODE_PROPS))
+                    && args.length > 0 && "mvn".equals(args[0]);
+        }
+
+        /**
          * URL-decodes values of -D Maven system property arguments.
          * Prevents double-encoding when user passes URL-encoded values (e.g. https%3A%2F%2F...)
          * to jf mvn, which would otherwise encode them again before sending to Artifactory.
          * Invalid percent sequences (e.g. "100%") are left unchanged.
-         * Enabled via JFROG_CLI_DECODE_PROPS=true env var (opt-in).
+         *
+         * @param args - The 'jf' command arguments
+         * @return the arguments, with the values of the -D arguments decoded.
          */
         static String[] decodeDPropertyValues(String[] args) {
             return Arrays.stream(args).map(arg -> {
@@ -162,13 +182,12 @@ public class JfStep extends Step {
                     return arg;
                 }
                 String key = arg.substring(0, eqIndex);
-                String value = arg.substring(eqIndex + 1);
+                // Escape '+' before decoding, so that it is not decoded into a space
+                String value = arg.substring(eqIndex + 1).replace("+", "%2B");
                 try {
-                    // Replace + with %2B before decoding so + is not decoded as space
-                    String toDecide = value.indexOf('+') >= 0 ? value.replace("+", "%2B") : value;
-                    String decoded = URLDecoder.decode(toDecide, StandardCharsets.UTF_8);
-                    return key + "=" + decoded;
+                    return key + "=" + URLDecoder.decode(value, StandardCharsets.UTF_8);
                 } catch (IllegalArgumentException e) {
+                    // Not a valid percent-encoded value (e.g. "100%") - keep it as is
                     return arg;
                 }
             }).toArray(String[]::new);

--- a/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfStep.java
@@ -28,8 +28,10 @@ import javax.annotation.Nonnull;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
@@ -119,7 +121,8 @@ public class JfStep extends Step {
             String jfrogBinaryPath = getJFrogCLIPath(env, isWindows);
             boolean passwordStdinSupported = isPasswordStdinEnabled(workspace, env, launcher, jfrogBinaryPath);
 
-            builder.add(jfrogBinaryPath).add(args);
+            String[] processedArgs = "true".equals(env.get("JFROG_CLI_DECODE_PROPS")) ? decodeDPropertyValues(args) : args;
+            builder.add(jfrogBinaryPath).add(processedArgs);
             if (isWindows) {
                 builder = builder.toWindowsCommand();
             }
@@ -140,6 +143,35 @@ public class JfStep extends Step {
                 throw new RuntimeException(errorMessage, e);
             }
             return output;
+        }
+
+        /**
+         * URL-decodes values of -D Maven system property arguments.
+         * Prevents double-encoding when user passes URL-encoded values (e.g. https%3A%2F%2F...)
+         * to jf mvn, which would otherwise encode them again before sending to Artifactory.
+         * Invalid percent sequences (e.g. "100%") are left unchanged.
+         * Enabled via JFROG_CLI_DECODE_PROPS=true env var (opt-in).
+         */
+        static String[] decodeDPropertyValues(String[] args) {
+            return Arrays.stream(args).map(arg -> {
+                if (!arg.startsWith("-D")) {
+                    return arg;
+                }
+                int eqIndex = arg.indexOf('=');
+                if (eqIndex < 0) {
+                    return arg;
+                }
+                String key = arg.substring(0, eqIndex);
+                String value = arg.substring(eqIndex + 1);
+                try {
+                    // Replace + with %2B before decoding so + is not decoded as space
+                    String toDecide = value.indexOf('+') >= 0 ? value.replace("+", "%2B") : value;
+                    String decoded = URLDecoder.decode(toDecide, StandardCharsets.UTF_8);
+                    return key + "=" + decoded;
+                } catch (IllegalArgumentException e) {
+                    return arg;
+                }
+            }).toArray(String[]::new);
         }
 
         /**

--- a/src/test/java/io/jenkins/plugins/jfrog/JfStepTest.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/JfStepTest.java
@@ -20,6 +20,7 @@ import java.util.stream.Stream;
 
 import static io.jenkins.plugins.jfrog.JfStep.Execution.decodeDPropertyValues;
 import static io.jenkins.plugins.jfrog.JfStep.Execution.getJFrogCLIPath;
+import static io.jenkins.plugins.jfrog.JfStep.Execution.shouldDecodeProps;
 import static io.jenkins.plugins.jfrog.JfStep.MIN_CLI_VERSION_PASSWORD_STDIN;
 import static io.jenkins.plugins.jfrog.JfrogInstallation.JFROG_BINARY_PATH;
 import static org.junit.jupiter.api.Assertions.*;
@@ -173,6 +174,34 @@ public class JfStepTest {
         assertArrayEquals(
                 new String[]{"-Ddeploy.committer=Sara++Ngo"},
                 decodeDPropertyValues(new String[]{"-Ddeploy.committer=Sara++Ngo"})
+        );
+    }
+
+    private static final String[] ENCODED_MVN_ARGS = new String[]{"mvn", "deploy", "-Ddeploy.scm.branch=feature%2F26.08"};
+
+    @ParameterizedTest
+    @MethodSource("decodePropsProvider")
+    void shouldDecodePropsTest(String envValue, String[] args, boolean expected) {
+        EnvVars env = new EnvVars();
+        if (envValue != null) {
+            env.put(JfStep.JFROG_CLI_DECODE_PROPS, envValue);
+        }
+        assertEquals(expected, shouldDecodeProps(env, args));
+    }
+
+    private static Stream<Arguments> decodePropsProvider() {
+        return Stream.of(
+                // Environment variable unset or disabled - arguments are passed to the CLI unchanged.
+                Arguments.of(null, ENCODED_MVN_ARGS, false),
+                Arguments.of("false", ENCODED_MVN_ARGS, false),
+                Arguments.of("", ENCODED_MVN_ARGS, false),
+                // Environment variable enabled - the check is case-insensitive.
+                Arguments.of("true", ENCODED_MVN_ARGS, true),
+                Arguments.of("TRUE", ENCODED_MVN_ARGS, true),
+                Arguments.of("True", ENCODED_MVN_ARGS, true),
+                // Enabled, but the command isn't 'jf mvn' - decoding does not apply.
+                Arguments.of("true", new String[]{"rt", "upload", "-Dkey=a%2Fb"}, false),
+                Arguments.of("true", new String[]{}, false)
         );
     }
 }

--- a/src/test/java/io/jenkins/plugins/jfrog/JfStepTest.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/JfStepTest.java
@@ -18,6 +18,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.stream.Stream;
 
+import static io.jenkins.plugins.jfrog.JfStep.Execution.decodeDPropertyValues;
 import static io.jenkins.plugins.jfrog.JfStep.Execution.getJFrogCLIPath;
 import static io.jenkins.plugins.jfrog.JfStep.MIN_CLI_VERSION_PASSWORD_STDIN;
 import static io.jenkins.plugins.jfrog.JfrogInstallation.JFROG_BINARY_PATH;
@@ -138,6 +139,40 @@ public class JfStepTest {
                 Arguments.of("2.31.3", envVarsFalse, passwordFlag),
                 // Minimum supported CLI version for password stdin
                 Arguments.of("2.31.3", envVarsTrue, passwordStdinFlag)
+        );
+    }
+
+    @Test
+    void testDecodeDPropertyValues() {
+        // URL-encoded values decoded
+        assertArrayEquals(
+                new String[]{"-Ddeploy.scm.location=https://checkout@scm.example.com/scm/repo.git"},
+                decodeDPropertyValues(new String[]{"-Ddeploy.scm.location=https%3A%2F%2Fcheckout%40scm.example.com%2Fscm%2Frepo.git"})
+        );
+        // URL-encoded branch decoded
+        assertArrayEquals(
+                new String[]{"-Ddeploy.scm.branch=feature/26.08"},
+                decodeDPropertyValues(new String[]{"-Ddeploy.scm.branch=feature%2F26.08"})
+        );
+        // Decoded value passes through unchanged
+        assertArrayEquals(
+                new String[]{"-Ddeploy.scm.location=https://checkout@scm.example.com/scm/repo.git"},
+                decodeDPropertyValues(new String[]{"-Ddeploy.scm.location=https://checkout@scm.example.com/scm/repo.git"})
+        );
+        // Non -D arg left unchanged
+        assertArrayEquals(
+                new String[]{"mvn", "deploy", "-DskipTests"},
+                decodeDPropertyValues(new String[]{"mvn", "deploy", "-DskipTests"})
+        );
+        // Invalid percent sequence kept as-is
+        assertArrayEquals(
+                new String[]{"-Dkey=100%"},
+                decodeDPropertyValues(new String[]{"-Dkey=100%"})
+        );
+        // + not decoded as space
+        assertArrayEquals(
+                new String[]{"-Ddeploy.committer=Sara++Ngo"},
+                decodeDPropertyValues(new String[]{"-Ddeploy.committer=Sara++Ngo"})
         );
     }
 }


### PR DESCRIPTION
- [x] This pull request is created in the [jfrog/jenkins-jfrog-plugin](https://github.com/jfrog/jenkins-jfrog-plugin) repository.

## fix: URL-decode `-D` property values before passing to JFrog CLI

### Problem
When pipelines pass URL-encoded Maven `-D` properties (e.g. `-Ddeploy.scm.location=https%3A%2F%2F...`), JFrog CLI encodes them again before sending to Artifactory. Artifactory single-decodes, leaving properties still URL-encoded on the artifact.

This broke customers migrating from the Jenkins Artifactory Plugin, where property values came from Jenkins environment variables and were already decoded.

### Fix
URL-decode `-D` argument values in `JfStep` before passing to JFrog CLI. The CLI then receives decoded values and encodes them correctly — one level of encoding — so Artifactory stores the expected decoded result.

Opt-in via `JFROG_CLI_DECODE_PROPS=true`. Default behavior unchanged.

### Usage
```groovy
environment {
    JFROG_CLI_DECODE_PROPS = "true"
}
