### PR TITLE
RTECO-0000 - Bump version to avoid curation block on plexus-archiver:4.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,6 @@
         <jenkins.version>2.462.3</jenkins.version>
         <skipITs>true</skipITs>
         <buildinfo.version>2.41.23</buildinfo.version>
-        <hpi-plugin.version>3.66</hpi-plugin.version>
     </properties>
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>jfrog</artifactId>
@@ -249,6 +248,20 @@
     </pluginRepositories>
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.jenkins-ci.tools</groupId>
+                <artifactId>maven-hpi-plugin</artifactId>
+                <extensions>true</extensions>
+                <dependencies>
+                    <!-- Override the plexus-archiver version pulled in transitively via
+                         maven-archiver, as the default (4.4.0) is blocked by curation. -->
+                    <dependency>
+                        <groupId>org.codehaus.plexus</groupId>
+                        <artifactId>plexus-archiver</artifactId>
+                        <version>4.10.0</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -12,10 +12,11 @@
         <jenkins.version>2.462.3</jenkins.version>
         <skipITs>true</skipITs>
         <buildinfo.version>2.41.23</buildinfo.version>
+        <hpi-plugin.version>3.66</hpi-plugin.version>
     </properties>
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>jfrog</artifactId>
-    <version>1.8.x-SNAPSHOT</version>
+    <version>1.9.0</version>
     <packaging>hpi</packaging>
     <name>JFrog Plugin</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     </properties>
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>jfrog</artifactId>
-    <version>1.9.0</version>
+    <version>1.8.x-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>JFrog Plugin</name>
 
@@ -224,6 +224,24 @@
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
+            <!-- The versions of the two dependencies below are pinned above the ones the BOM
+                 resolves to, because the BOM's versions are blocked by curation. -->
+            <dependency>
+                <groupId>io.jenkins.plugins</groupId>
+                <artifactId>lib-durable-task</artifactId>
+                <version>79.v132950154068</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.main</groupId>
+                <artifactId>jenkins-test-harness-htmlunit</artifactId>
+                <version>226.v08d56c2329f7</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>durable-task</artifactId>
+                <version>581.v299a_5609d767</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <repositories>
@@ -253,12 +271,25 @@
                 <artifactId>maven-hpi-plugin</artifactId>
                 <extensions>true</extensions>
                 <dependencies>
-                    <!-- Override the plexus-archiver version pulled in transitively via
-                         maven-archiver, as the default (4.4.0) is blocked by curation. -->
+                    <!-- Override the plexus-archiver version pulled in transitively via maven-archiver:
+                         the default (4.4.0) is blocked by curation for CVE-2023-37460, fixed in 4.8.0+. -->
                     <dependency>
                         <groupId>org.codehaus.plexus</groupId>
                         <artifactId>plexus-archiver</artifactId>
                         <version>4.10.0</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin>
+                <groupId>org.jvnet.localizer</groupId>
+                <artifactId>localizer-maven-plugin</artifactId>
+                <dependencies>
+                    <!-- Same curation issue as above (default is 4.2.0). CVE-2023-37460 is only fixed in 4.8.0+,
+                         so an intermediate version would just get blocked once curation evaluates it. -->
+                    <dependency>
+                        <groupId>org.codehaus.plexus</groupId>
+                        <artifactId>plexus-archiver</artifactId>
+                        <version>4.8.0</version>
                     </dependency>
                 </dependencies>
             </plugin>
@@ -294,7 +325,8 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.1</version>
+                <!-- 2.22.2 rather than 2.22.1: the 2.22.1 surefire-junit-platform provider is blocked by curation. -->
+                <version>2.22.2</version>
                 <configuration>
                     <systemPropertyVariables>
                         <!--This will disable JenkinsRule timeout-->
@@ -310,7 +342,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.22.1</version>
+                <version>2.22.2</version>
                 <configuration>
                     <systemPropertyVariables>
                         <!--This will disable JenkinsRule timeout-->

--- a/pom.xml
+++ b/pom.xml
@@ -272,11 +272,11 @@
                 <extensions>true</extensions>
                 <dependencies>
                     <!-- Override the plexus-archiver version pulled in transitively via maven-archiver:
-                         the default (4.4.0) is blocked by curation for CVE-2023-37460, fixed in 4.8.0+. -->
+                         the default (4.4.0) is blocked by curation for CVE-2023-37460, which is fixed in 4.8.0. -->
                     <dependency>
                         <groupId>org.codehaus.plexus</groupId>
                         <artifactId>plexus-archiver</artifactId>
-                        <version>4.10.0</version>
+                        <version>4.8.0</version>
                     </dependency>
                 </dependencies>
             </plugin>
@@ -284,8 +284,8 @@
                 <groupId>org.jvnet.localizer</groupId>
                 <artifactId>localizer-maven-plugin</artifactId>
                 <dependencies>
-                    <!-- Same curation issue as above (default is 4.2.0). CVE-2023-37460 is only fixed in 4.8.0+,
-                         so an intermediate version would just get blocked once curation evaluates it. -->
+                    <!-- Same curation issue as above, where the default is 4.2.0. An intermediate version
+                         would only get blocked again once curation evaluates it, since the fix landed in 4.8.0. -->
                     <dependency>
                         <groupId>org.codehaus.plexus</groupId>
                         <artifactId>plexus-archiver</artifactId>


### PR DESCRIPTION
- [ ] This pull request is created in the [jfrog/jenkins-jfrog-plugin](https://github.com/jfrog/jenkins-jfrog-plugin) repository.
