### PR TITLE
RTECO-1659 - NO_PROXY Values Propagated in Java Wildcard Format

### DIFF
--- a/src/main/java/io/jenkins/plugins/jfrog/CliEnvConfigurator.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/CliEnvConfigurator.java
@@ -9,6 +9,7 @@ import org.apache.commons.lang3.StringUtils;
 import java.io.IOException;
 import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.logging.Logger;
 import java.util.regex.Pattern;
 
 /**
@@ -17,6 +18,7 @@ import java.util.regex.Pattern;
  * @author yahavi
  **/
 public class CliEnvConfigurator {
+    private static final Logger logger = Logger.getLogger(CliEnvConfigurator.class.getName());
     static final String JFROG_CLI_DEFAULT_EXCLUSIONS = "*password*;*psw*;*secret*;*key*;*token*;*auth*";
     static final String JFROG_CLI_ENCRYPTION_KEY = "JFROG_CLI_ENCRYPTION_KEY";
     static final String JFROG_CLI_BUILD_NUMBER = "JFROG_CLI_BUILD_NUMBER";
@@ -140,7 +142,13 @@ public class CliEnvConfigurator {
         String suffix = StringUtils.strip(host.substring(host.lastIndexOf('*') + 1), ".");
         if (suffix.isEmpty()) {
             // Patterns such as 'jfrog.*' have no suffix to match on - fall back to their literal part
-            return StringUtils.strip(host.replace("*", ""), ".");
+            String literal = StringUtils.strip(host.replace("*", ""), ".");
+            if (literal.isEmpty()) {
+                logger.warning("NO_PROXY entry '" + entry + "' has no translatable suffix and will be dropped.");
+                return "";
+            }
+            logger.warning("NO_PROXY entry '" + entry + "' cannot be expressed as a suffix; using literal '" + literal + "' instead.");
+            return literal;
         }
         return "." + suffix;
     }

--- a/src/main/java/io/jenkins/plugins/jfrog/CliEnvConfigurator.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/CliEnvConfigurator.java
@@ -7,6 +7,9 @@ import io.jenkins.plugins.jfrog.configuration.JenkinsProxyConfiguration;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.regex.Pattern;
 
 /**
  * Configures JFrog CLI environment variables for the job.
@@ -24,6 +27,8 @@ public class CliEnvConfigurator {
     static final String HTTPS_PROXY_ENV = "HTTPS_PROXY";
     static final String HTTP_PROXY_ENV = "HTTP_PROXY";
     static final String NO_PROXY = "NO_PROXY";
+    // Jenkins expects the 'No Proxy Host' list to be newline separated, but also tolerates spaces, '|', ';' and ','
+    private static final Pattern NO_PROXY_SEPARATORS = Pattern.compile("[\\s|;,]+");
 
     /**
      * Configure the JFrog CLI environment variables, according to the input job's env.
@@ -91,14 +96,52 @@ public class CliEnvConfigurator {
 
     /**
      * Converts a list of No Proxy Hosts received by Jenkins into a comma-separated string format expected by JFrog CLI.
+     * Jenkins holds the hosts as Java-style wildcard patterns, such as '*.jfrog.io'. Every entry is normalized into a
+     * plain host or a host suffix, so that the tools invoked by JFrog CLI - curl, npm and others - which match
+     * NO_PROXY entries as suffixes rather than as wildcard patterns, honor the exclusions as well.
      *
      * @param noProxy - A string representing the list of No Proxy Hosts.
      * @return A comma-separated string of No Proxy Hosts.
      */
     static String createNoProxyValue(String noProxy) {
-        // Trim leading and trailing spaces, Replace '|' and ';' with spaces and normalize whitespace
-        String noProxyListRemoveSpaceAndPipe = noProxy.trim().replaceAll("[\\s|;]+", ",");
-        // Replace multiple commas with a single comma, and remove the last one if present
-        return noProxyListRemoveSpaceAndPipe.replaceAll(",+", ",").replaceAll("^,|,$", "");
+        if (StringUtils.isBlank(noProxy)) {
+            return "";
+        }
+        // Stripping the wildcards may produce duplicates, for example out of both '*.jfrog.io' and '.jfrog.io'
+        Set<String> hosts = new LinkedHashSet<>();
+        for (String entry : NO_PROXY_SEPARATORS.split(noProxy.trim())) {
+            String host = normalizeNoProxyHost(entry);
+            if (!host.isEmpty()) {
+                hosts.add(host);
+            }
+        }
+        return String.join(",", hosts);
+    }
+
+    /**
+     * Convert a single Jenkins 'No Proxy Host' entry into a format understood by CLI tools.
+     * Such tools match a NO_PROXY entry against the target host as an exact name or as a suffix, and treat a '*' as a
+     * literal character. Therefore, the only translatable part of a wildcard pattern is the literal text that follows
+     * its last '*': '*.jfrog.io' becomes the suffix '.jfrog.io', which matches every subdomain of jfrog.io.
+     *
+     * @param entry - A single No Proxy Host entry, may contain wildcards.
+     * @return The normalized host, or an empty string if the entry contains no host to match on.
+     */
+    private static String normalizeNoProxyHost(String entry) {
+        String host = entry.trim();
+        if (host.indexOf('*') < 0) {
+            // A plain host, an IP or a CIDR block - already in the expected format
+            return host;
+        }
+        if (host.equals("*")) {
+            // A lone '*' means "bypass the proxy for all hosts" and is supported as is
+            return host;
+        }
+        String suffix = StringUtils.strip(host.substring(host.lastIndexOf('*') + 1), ".");
+        if (suffix.isEmpty()) {
+            // Patterns such as 'jfrog.*' have no suffix to match on - fall back to their literal part
+            return StringUtils.strip(host.replace("*", ""), ".");
+        }
+        return "." + suffix;
     }
 }

--- a/src/test/java/io/jenkins/plugins/jfrog/CreateNoProxyValueTest.java
+++ b/src/test/java/io/jenkins/plugins/jfrog/CreateNoProxyValueTest.java
@@ -39,7 +39,30 @@ public class CreateNoProxyValueTest {
                 new Object[]{"artifactory.jfrog.io\nartifactory1.jfrog.io", "artifactory.jfrog.io,artifactory1.jfrog.io"},
                 new Object[]{"artifactory.jfrog.io \nartifactory1.jfrog.io\nartifactory2.jfrog.io  \n  artifactory3.jfrog.io", "artifactory.jfrog.io,artifactory1.jfrog.io,artifactory2.jfrog.io,artifactory3.jfrog.io"},
                 new Object[]{";artifactory.jfrog.io;", "artifactory.jfrog.io"},
-                new Object[]{",artifactory.jfrog.io,", "artifactory.jfrog.io"}
+                new Object[]{",artifactory.jfrog.io,", "artifactory.jfrog.io"},
+
+                // Jenkins wildcard patterns are normalized into the host suffixes expected by CLI tools
+                new Object[]{"*.jfrog.io", ".jfrog.io"},
+                new Object[]{"*jfrog.io", ".jfrog.io"},
+                new Object[]{"artifactory*.jfrog.io", ".jfrog.io"},
+                new Object[]{"*.*.jfrog.io", ".jfrog.io"},
+                new Object[]{"*.jfrog.io\n*.acme.io", ".jfrog.io,.acme.io"},
+                new Object[]{"*.jfrog.io;artifactory.acme.io", ".jfrog.io,artifactory.acme.io"},
+                new Object[]{"*.jfrog.io | *.acme.io", ".jfrog.io,.acme.io"},
+                // A lone '*' bypasses the proxy for all hosts and is understood as is
+                new Object[]{"*", "*"},
+                // Duplicates created by stripping the wildcards are removed
+                new Object[]{"*.jfrog.io,.jfrog.io", ".jfrog.io"},
+                new Object[]{"*.jfrog.io\nartifactory*.jfrog.io", ".jfrog.io"},
+                // Patterns with nothing to match on after the wildcard fall back to their literal part
+                new Object[]{"jfrog.*", "jfrog"},
+                new Object[]{"10.0.*", "10.0"},
+                new Object[]{"*.*", ""},
+                // Entries that need no translation are left untouched
+                new Object[]{".jfrog.io", ".jfrog.io"},
+                new Object[]{"10.0.0.0/16", "10.0.0.0/16"},
+                new Object[]{"artifactory.jfrog.io:8081", "artifactory.jfrog.io:8081"},
+                new Object[]{"localhost", "localhost"}
         );
     }
 


### PR DESCRIPTION
## Summary

Jenkins holds its "No Proxy Host" list as Java-style wildcard patterns (`*.example.com`), and the plugin copied them into `NO_PROXY` verbatim. The tools JFrog CLI shells out to — curl, npm and others — match a `NO_PROXY` entry as an exact host or as a host suffix, and treat `*` as a literal character. Such an entry never matches any real hostname, so the excluded hosts are sent through the proxy anyway.

`createNoProxyValue` now normalizes every entry instead of only rewriting separators.

## Behavior

| Jenkins "No Proxy Host" | `NO_PROXY` before | `NO_PROXY` after |
|---|---|---|
| `*.example.com` | `*.example.com` | `.example.com` |
| `*example.com` | `*example.com` | `.example.com` |
| `foo*.example.com` | `foo*.example.com` | `.example.com` |
| `*.example.com;artifactory.jfrog.io` | `*.example.com,artifactory.jfrog.io` | `.example.com,artifactory.jfrog.io` |
| `*` | `*` | `*` (unchanged) |
| `example.com`, `10.0.0.0/16`, `host:8081` | unchanged | unchanged |

The rule: since `*` has no meaning to these tools, the only translatable part of a wildcard pattern is the literal text following its **last** `*`, emitted as a dot-prefixed suffix. Entries without a wildcard pass through untouched, a lone `*` (bypass everything) is preserved, and duplicates that wildcard-stripping can create are removed while keeping the original order.

Scope note: JFrog CLI's own HTTP traffic was never affected — Go's `net/http` strips a leading `*` from `NO_PROXY` entries. This only bit the tools the CLI invokes, so the customer-visible symptom is `jf npm` / `jf mvn` failing against an internal host once a Jenkins proxy is configured.

## Testing

- `CreateNoProxyValueTest`: 17 cases added (wildcard positions, dedup, lone `*`, CIDR/port/plain hosts, degenerate `jfrog.*`). All 14 pre-existing cases still pass, so separator handling is unchanged.
- Full suite: **184 tests, 0 failures, 0 errors.**

Verified end to end in a local Jenkins (`mvn hpi:run`) with proxy `127.0.0.1:9` (nothing listening) and "No Proxy Host" set to `*.example.com`. A stand-in `jf` on the PATH reported the environment it received and ran `curl` with it. curl's exit code identifies the route taken: `7` = reached the dead proxy (exclusion ignored), `6` = resolved the hostname itself (exclusion honored).

Before:
```
NO_PROXY      : *.example.com
curl route    : 7 -> went via PROXY   => exclusion IGNORED
```

After, with the Jenkins field left as `*.example.com`:
```
NO_PROXY      : .example.com
curl route    : 6 -> went DIRECT     => exclusion HONORED
```

## For reviewers

`foo*.example.com` normalizes to `.example.com`, which is **broader** than Jenkins' own matching. This was deliberate: under-matching sends traffic the user explicitly excluded to the proxy — the very failure being fixed — whereas over-matching only routes more traffic directly. If narrowing is preferred, it's a small change in `normalizeNoProxyHost`.

Patterns with no suffix after the wildcard (`jfrog.*`, `10.0.*`) have no `NO_PROXY` equivalent at all. They fall back to their literal part (`jfrog`, `10.0`) rather than being dropped silently. For IP ranges, a CIDR block such as `10.0.0.0/16` is the supported form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
